### PR TITLE
Over-temperature protection

### DIFF
--- a/Software/PC_Application/preferences.cpp
+++ b/Software/PC_Application/preferences.cpp
@@ -81,6 +81,10 @@ PreferencesDialog::PreferencesDialog(Preferences *pref, QWidget *parent) :
         ui->GeneralSCPIPort->setEnabled(false);
         ui->GeneralSCPIEnabled->setEnabled(false);
     }
+    ui->GeneralTemperatureWarn_Action->addItem("Warning only");
+    ui->GeneralTemperatureWarn_Action->addItem("Warning & device disconnect");
+    ui->GeneralTemperatureWarn_Action->addItem("No action (not recommended)");
+
 
     // Page selection
     connect(ui->treeWidget, &QTreeWidget::currentItemChanged, [=](QTreeWidgetItem *current, QTreeWidgetItem *) {
@@ -130,6 +134,8 @@ PreferencesDialog::PreferencesDialog(Preferences *pref, QWidget *parent) :
         p->General.graphColors.divisions = ui->GeneralGraphDivisions->getColor();
         p->General.SCPI.enabled = ui->GeneralSCPIEnabled->isChecked();
         p->General.SCPI.port = ui->GeneralSCPIPort->value();
+        p->General.HWTemp.warnLimit = ui->GeneralTemperatureWarn_Limit->value();
+        p->General.HWTemp.warnAction = ui->GeneralTemperatureWarn_Action->currentIndex();
         accept();
     });
 
@@ -186,6 +192,8 @@ void PreferencesDialog::setInitialGUIState()
     ui->GeneralGraphDivisions->setColor(p->General.graphColors.divisions);
     ui->GeneralSCPIEnabled->setChecked(p->General.SCPI.enabled);
     ui->GeneralSCPIPort->setValue(p->General.SCPI.port);
+    ui->GeneralTemperatureWarn_Limit->setValue(p->General.HWTemp.warnLimit);
+    ui->GeneralTemperatureWarn_Action->setCurrentIndex(p->General.HWTemp.warnAction);
 
     QTreeWidgetItem *item = ui->treeWidget->topLevelItem(0);
     if (item != nullptr) {

--- a/Software/PC_Application/preferences.cpp
+++ b/Software/PC_Application/preferences.cpp
@@ -81,7 +81,7 @@ PreferencesDialog::PreferencesDialog(Preferences *pref, QWidget *parent) :
         ui->GeneralSCPIPort->setEnabled(false);
         ui->GeneralSCPIEnabled->setEnabled(false);
     }
-    ui->GeneralTemperatureWarn_Action->addItem("Warning only");
+    ui->GeneralTemperatureWarn_Action->addItem("Warning only"); // available actions if warning temperature reached
     ui->GeneralTemperatureWarn_Action->addItem("Warning & device disconnect");
     ui->GeneralTemperatureWarn_Action->addItem("No action (not recommended)");
 

--- a/Software/PC_Application/preferences.h
+++ b/Software/PC_Application/preferences.h
@@ -60,6 +60,10 @@ public:
             bool enabled;
             int port;
         } SCPI;
+        struct {
+            int warnLimit;
+            int warnAction;
+        } HWTemp;
     } General;
 
     bool TCPoverride; // in case of manual port specification via command line
@@ -72,7 +76,7 @@ private:
         QString name;
         QVariant def;
     };
-    const std::array<SettingDescription, 27> descr = {{
+    const std::array<SettingDescription, 29> descr = {{
         {&Startup.ConnectToFirstDevice, "Startup.ConnectToFirstDevice", true},
         {&Startup.RememberSweepSettings, "Startup.RememberSweepSettings", false},
         {&Startup.DefaultSweep.start, "Startup.DefaultSweep.start", 1000000.0},
@@ -100,6 +104,8 @@ private:
         {&General.graphColors.divisions, "General.graphColors.divisions", QColor(Qt::gray)},
         {&General.SCPI.enabled, "General.SCPI.enabled", true},
         {&General.SCPI.port, "General.SCPI.port", 19542},
+        {&General.HWTemp.warnLimit, "General.HWTemperature.warnLimit", 70},
+        {&General.HWTemp.warnAction, "General.HWTemperature.warnAction", 0},
     }};
 };
 

--- a/Software/PC_Application/preferences.h
+++ b/Software/PC_Application/preferences.h
@@ -61,9 +61,13 @@ public:
             int port;
         } SCPI;
         struct {
+            // warning temperature
             int warnLimit;
             int warnAction;
-        } HWTemp;
+            // critical temperature (future improvement)
+            // int criticalLimit
+            // int criticalAction
+        } HWTemp;   // related to embedded device temperatures
     } General;
 
     bool TCPoverride; // in case of manual port specification via command line

--- a/Software/PC_Application/preferencesdialog.ui
+++ b/Software/PC_Application/preferencesdialog.ui
@@ -625,6 +625,48 @@
               </widget>
              </item>
              <item>
+              <widget class="QGroupBox" name="groupBox_9">
+               <property name="title">
+                <string>Hardware</string>
+               </property>
+               <layout class="QVBoxLayout" name="verticalLayout_9">
+                <item>
+                 <widget class="QGroupBox" name="groupBox_10">
+                  <property name="title">
+                   <string>Temperature</string>
+                  </property>
+                  <layout class="QVBoxLayout" name="verticalLayout_10">
+                   <item>
+                    <layout class="QHBoxLayout" name="horizontalLayout_8">
+                     <item>
+                      <widget class="QSpinBox" name="GeneralTemperatureWarn_Limit">
+                       <property name="showGroupSeparator" stdset="0">
+                        <bool>false</bool>
+                       </property>
+                       <property name="value">
+                        <number>70</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QLabel" name="label_21">
+                       <property name="text">
+                        <string>Celsius</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </item>
+                   <item>
+                    <widget class="QComboBox" name="GeneralTemperatureWarn_Action"/>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
               <spacer name="verticalSpacer_3">
                <property name="orientation">
                 <enum>Qt::Vertical</enum>

--- a/Software/VNA_embedded/Application/Communication/Communication.cpp
+++ b/Software/VNA_embedded/Application/Communication/Communication.cpp
@@ -50,15 +50,19 @@ bool Communication::Send(const Protocol::PacketInfo &packet) {
 //	DEBUG1_LOW();
 
 	// return usb_transmit(outputBuffer, len);
-	bool txResult = usb_transmit(outputBuffer, len);
-	if(packet.type == Protocol::PacketType::DeviceInfo){
-		if(packet.info.temp_over_hardLimit == true){
+	bool txResult = usb_transmit(outputBuffer, len);        // transmit packet normally, save result
+	if(packet.type == Protocol::PacketType::DeviceInfo){    // if DeviceInfo
+		if(packet.info.temp_over_hardLimit == true){        // and if overtemperature detected
 			HW::Init();	// Skip this? (may not complete in case of a HW problem)
 			HW::SetIdle();
 			// how to disconnect usb?
+			// ?
+			// if usb disconnected in previous step
+			   // then return false??
+			//
 		}
 	}
-	return txResult;
+	return txResult;    // return usb transmission result
 
 //	if (hUsbDeviceFS.dev_state == USBD_STATE_CONFIGURED) {
 //		uint16_t len = Protocol::EncodePacket(packet, outputBuffer,

--- a/Software/VNA_embedded/Application/Communication/Communication.cpp
+++ b/Software/VNA_embedded/Application/Communication/Communication.cpp
@@ -48,7 +48,18 @@ bool Communication::Send(const Protocol::PacketInfo &packet) {
 	uint16_t len = Protocol::EncodePacket(packet, outputBuffer,
 					sizeof(outputBuffer));
 //	DEBUG1_LOW();
-	return usb_transmit(outputBuffer, len);
+
+	// return usb_transmit(outputBuffer, len);
+	bool txResult = usb_transmit(outputBuffer, len);
+	if(packet.type == Protocol::PacketType::DeviceInfo){
+		if(packet.info.temp_over_hardLimit == true){
+			HW::Init();	// Skip this? (may not complete in case of a HW problem)
+			HW::SetIdle();
+			// how to disconnect usb?
+		}
+	}
+	return txResult;
+
 //	if (hUsbDeviceFS.dev_state == USBD_STATE_CONFIGURED) {
 //		uint16_t len = Protocol::EncodePacket(packet, outputBuffer,
 //				sizeof(outputBuffer));

--- a/Software/VNA_embedded/Application/Communication/Protocol.hpp
+++ b/Software/VNA_embedded/Application/Communication/Protocol.hpp
@@ -41,7 +41,8 @@ using GeneratorSettings = struct _generatorSettings {
     uint8_t applyAmplitudeCorrection :1;
 };
 
-static constexpr int8_t TemperatureLimit_Hard = 85;	// minimum(PLL, MCU, FPGA, etc). Subtract a few for safety margin?
+static constexpr int8_t TemperatureLimit_Hard = 85;	// minimum(PLL, MCU, FPGA, etc)
+													// Maybe 80 degrees, for additional safety margin?
 using DeviceInfo = struct _deviceInfo {
 	uint16_t ProtocolVersion;
     uint8_t FW_major;

--- a/Software/VNA_embedded/Application/Communication/Protocol.hpp
+++ b/Software/VNA_embedded/Application/Communication/Protocol.hpp
@@ -41,6 +41,7 @@ using GeneratorSettings = struct _generatorSettings {
     uint8_t applyAmplitudeCorrection :1;
 };
 
+static constexpr int8_t TemperatureLimit_Hard = 85;	// minimum(PLL, MCU, FPGA, etc). Subtract a few for safety margin?
 using DeviceInfo = struct _deviceInfo {
 	uint16_t ProtocolVersion;
     uint8_t FW_major;
@@ -68,6 +69,7 @@ using DeviceInfo = struct _deviceInfo {
 	uint32_t limits_maxRBW;
     uint8_t limits_maxAmplitudePoints;
     uint64_t limits_maxFreqHarmonic;
+    bool temp_over_hardLimit;
 };
 
 using ManualStatus = struct _manualstatus {

--- a/Software/VNA_embedded/Application/Hardware.cpp
+++ b/Software/VNA_embedded/Application/Hardware.cpp
@@ -325,6 +325,7 @@ void HW::fillDeviceInfo(Protocol::DeviceInfo *info, bool updateEvenWhenBusy) {
 		info->temp_source = tempSource;
 		FPGA::ResetADCLimits();
 		if( (temp_LO > Protocol::TemperatureLimit_Hard) || (tempSource > Protocol::TemperatureLimit_Hard) ){
+			// if any temperature limit crossed, set flag
 			info->temp_over_hardLimit = true;
 		}
 	}
@@ -332,6 +333,7 @@ void HW::fillDeviceInfo(Protocol::DeviceInfo *info, bool updateEvenWhenBusy) {
 	auto stmTemp = STM::getTemperature();
 	info->temp_MCU = stmTemp;
 	if(stmTemp > Protocol::TemperatureLimit_Hard){
+		// also if mcu temperature limit crossed, set flag
 		info->temp_over_hardLimit = true;
 	}
 }

--- a/Software/VNA_embedded/Application/Hardware.cpp
+++ b/Software/VNA_embedded/Application/Hardware.cpp
@@ -307,7 +307,7 @@ void HW::fillDeviceInfo(Protocol::DeviceInfo *info, bool updateEvenWhenBusy) {
 		LOG_INFO("ADC limits: P1: %d/%d P2: %d/%d R: %d/%d",
 				limits.P1min, limits.P1max, limits.P2min, limits.P2max,
 				limits.Rmin, limits.Rmax);
-	#define ADC_LIMIT 		30000
+		#define ADC_LIMIT 		30000
 		if(limits.P1min < -ADC_LIMIT || limits.P1max > ADC_LIMIT
 				|| limits.P2min < -ADC_LIMIT || limits.P2max > ADC_LIMIT
 				|| limits.Rmin < -ADC_LIMIT || limits.Rmax > ADC_LIMIT) {
@@ -324,8 +324,16 @@ void HW::fillDeviceInfo(Protocol::DeviceInfo *info, bool updateEvenWhenBusy) {
 		info->temp_LO1 = tempLO;
 		info->temp_source = tempSource;
 		FPGA::ResetADCLimits();
+		if( (temp_LO > Protocol::TemperatureLimit_Hard) || (tempSource > Protocol::TemperatureLimit_Hard) ){
+			info->temp_over_hardLimit = true;
+		}
 	}
-	info->temp_MCU = STM::getTemperature();
+//	info->temp_MCU = STM::getTemperature();
+	auto stmTemp = STM::getTemperature();
+	info->temp_MCU = stmTemp;
+	if(stmTemp > Protocol::TemperatureLimit_Hard){
+		info->temp_over_hardLimit = true;
+	}
 }
 
 bool HW::Ref::available() {


### PR DESCRIPTION
Hello!
The more I dig, the more I am impressed...enough said. :)

Here is my humble attempt to implement device overtemperature protection, as in #13  and, described in https://github.com/jankae/LibreVNA/issues/13#issuecomment-824184702

Embedded:
Added flag in DeviceInfo, hard limit value in protocol.hpp. Please suggest actual value, such as 80, 85 degrees?
Hardware.cpp - set flag if any chip is over the limit.
Communication.cpp - send packet through usb anyway, then check flag and also perform hardcoded action if needed (power down or such...). Considered implementing this elsewhere, but it seems this is the common place for all modes (vna, generator, sa), to check flag and act immediately if needed. Suggestions are welcome.

p.s. do we need per-chip specific temperature limits? I think that would be an overkill.

PC Application:
Added gui and preference values for temperature limit and appropriate action.
I named them warning_xxx, in anticipation of possible critical_xxx activities (although ulikely as this will be handled directly in the embedded device).

I welcome your comments on the proposed changes. I hope I am not missing the poit of my homework too much :)
I am not absolutely happy with the code, but it depends on your/my personal style, vision and skill. For example, I would like some kind of enum for the (warn/disconnect/no action) combobox, but I struggle here a bit...
Also, without the working toolchain for stm32, I was not able to test this at all, so I relied on eclipse's syntax checking alone.


What is missing?
Still need to check every packet arriving to the pc application and perform chosen action. I'd like to hear your comments before going there.
