### PR TITLE
make: set BINPATH as fallback when compiling

### DIFF
--- a/Software/VNA_embedded/Makefile
+++ b/Software/VNA_embedded/Makefile
@@ -70,7 +70,7 @@ PERIFLIB_SOURCES =
 #######################################
 # binaries
 #######################################
-BINPATH = /usr/bin
+BINPATH ?= /usr/bin
 PREFIX = arm-none-eabi-
 CC = $(BINPATH)/$(PREFIX)gcc
 CXX  = $(BINPATH)/$(PREFIX)g++


### PR DESCRIPTION
This change introduce a way to modify BINPATH
outside makefile when compiling, allowing developer
to choose from where toolchain is coming and at
same time avoiding to pollute upstream.