### PR TITLE
implement about dialog, refactor app version/hash

### DIFF
--- a/Software/PC_Application/LibreVNA-GUI.pro
+++ b/Software/PC_Application/LibreVNA-GUI.pro
@@ -102,6 +102,7 @@ HEADERS += \
     Traces/xyplotaxisdialog.h \
     Util/qpointervariant.h \
     Util/util.h \
+    Util/app_common.h \
     VNA/Deembedding/deembedding.h \
     VNA/Deembedding/deembeddingdialog.h \
     VNA/Deembedding/deembeddingoption.h \
@@ -111,6 +112,7 @@ HEADERS += \
     VNA/Deembedding/twothru.h \
     VNA/tracewidgetvna.h \
     VNA/vna.h \
+    about.h \
     appwindow.h \
     averaging.h \
     csv.h \
@@ -223,6 +225,7 @@ SOURCES += \
     VNA/Deembedding/twothru.cpp \
     VNA/tracewidgetvna.cpp \
     VNA/vna.cpp \
+    about.cpp \
     appwindow.cpp \
     averaging.cpp \
     csv.cpp \
@@ -285,6 +288,7 @@ FORMS += \
     VNA/Deembedding/portextensioneditdialog.ui \
     VNA/Deembedding/twothrudialog.ui \
     VNA/s2pImportOptions.ui \
+    aboutdialog.ui \
     main.ui \
     preferencesdialog.ui
 

--- a/Software/PC_Application/Util/app_common.h
+++ b/Software/PC_Application/Util/app_common.h
@@ -1,0 +1,8 @@
+#ifndef APP_COMMON_H
+#define APP_COMMON_H
+
+#include <QApplication>
+
+#define qlibrevnaApp (QCoreApplication::instance())
+
+#endif  // APP_COMMON_H

--- a/Software/PC_Application/about.cpp
+++ b/Software/PC_Application/about.cpp
@@ -1,0 +1,33 @@
+#include "Util/app_common.h"
+#include "about.h"
+#include "ui_aboutdialog.h"
+
+About About::instance;
+
+AboutDialog::AboutDialog(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::AboutDialog)
+{
+    ui->setupUi(this);
+    setWindowTitle("About " + qlibrevnaApp->applicationName());
+    ui->appName->setText(qlibrevnaApp->applicationName());
+    ui->appVersion->setText(QString("Version: %1")
+        .arg(qlibrevnaApp->applicationVersion()));
+    ui->sourceCodeDescription->setText(QString("<a href='%1'>%1</a>")
+        .arg("https://github.com/jankae/LibreVNA"));
+    ui->sourceCodeDescription->setOpenExternalLinks(true);
+    ui->contributeDescription->setOpenExternalLinks(true);
+    ui->headerDescription->setOpenExternalLinks(true);
+}
+
+
+AboutDialog::~AboutDialog()
+{
+    delete ui;
+}
+
+void About::about()
+{
+    auto dialog = new AboutDialog();
+    dialog->exec();
+}

--- a/Software/PC_Application/about.h
+++ b/Software/PC_Application/about.h
@@ -1,0 +1,34 @@
+#ifndef ABOUT_H
+#define ABOUT_H
+
+#include <QDialog>
+
+class About
+{
+public:
+    static About& getInstance() {
+        return instance;
+    }
+    void about();
+private:
+    About() {};
+    static About instance;
+};
+
+namespace Ui
+{
+  class AboutDialog;
+}
+
+class AboutDialog : public QDialog
+{
+    Q_OBJECT
+public:
+    explicit AboutDialog(QWidget *parent = nullptr);
+    ~AboutDialog();
+
+private:
+    Ui::AboutDialog *ui;
+};
+
+#endif // ABOUT_H

--- a/Software/PC_Application/aboutdialog.ui
+++ b/Software/PC_Application/aboutdialog.ui
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>AboutDialog</class>
+ <widget class="QDialog" name="AboutDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>381</width>
+    <height>344</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <property name="layoutDirection">
+   <enum>Qt::LeftToRight</enum>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_3">
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout_5">
+     <item>
+      <widget class="QLabel" name="appName">
+       <property name="text">
+        <string>PLACEHOLDER_APP_NAME</string>
+       </property>
+       <property name="textFormat">
+        <enum>Qt::AutoText</enum>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="appVersion">
+       <property name="text">
+        <string>PLACEHOLDER_MAIN</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QTabWidget" name="tabWidget">
+       <property name="currentIndex">
+        <number>0</number>
+       </property>
+       <widget class="QWidget" name="tabInformation">
+        <attribute name="title">
+         <string>Information</string>
+        </attribute>
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <item>
+          <layout class="QVBoxLayout" name="verticalLayout">
+           <property name="spacing">
+            <number>6</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="informationDescription">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="autoFillBackground">
+              <bool>false</bool>
+             </property>
+             <property name="text">
+              <string>LibreVNA it's a Vector Network Analyzer instrument that comes with a set of tools aside of hardware as LibreVNA-GUI application and the firmware that runs over theboard itself. </string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="headerCommunity">
+             <property name="text">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;LibreVNA Community&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="textFormat">
+              <enum>Qt::AutoText</enum>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="headerDescription">
+             <property name="text">
+              <string>For general questions or discussions, the &lt;a href=&quot;https://groups.io/g/LibreVNA&quot;&gt;LibreVNA group&lt;/a&gt; is probably the best place.</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="headerSourceCode">
+             <property name="text">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;LibreVNA Source Code&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="sourceCodeDescription">
+             <property name="text">
+              <string>PLACEHOLDER_SOURCE_CODE_DESC</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="verticalSpacer">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="tabContribute">
+        <attribute name="title">
+         <string>Contribute</string>
+        </attribute>
+        <layout class="QVBoxLayout" name="verticalLayout_4">
+         <item>
+          <layout class="QVBoxLayout" name="verticalLayout_2">
+           <item>
+            <widget class="QLabel" name="contributeDescription">
+             <property name="layoutDirection">
+              <enum>Qt::LeftToRight</enum>
+             </property>
+             <property name="text">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Pull request are always welcome and this project is always in on-going development. If you have any proposal or feature just go to: &lt;a href=&quot;https://github.com/jankae/LibreVNA/issues&quot;&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;LibreVNA issues&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="verticalSpacer_2">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/Software/PC_Application/aboutdialog.ui
+++ b/Software/PC_Application/aboutdialog.ui
@@ -73,7 +73,7 @@
               <bool>false</bool>
              </property>
              <property name="text">
-              <string>LibreVNA it's a Vector Network Analyzer instrument that comes with a set of tools aside of hardware as LibreVNA-GUI application and the firmware that runs over theboard itself. </string>
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;LibreVNA is a Vector Network Analyzer that consists of the hardware, the LibreVNA-GUI (this application) and the firmware/FPGA configuration on the board. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
              <property name="wordWrap">
               <bool>true</bool>
@@ -144,7 +144,7 @@
               <enum>Qt::LeftToRight</enum>
              </property>
              <property name="text">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Pull request are always welcome and this project is always in on-going development. If you have any proposal or feature just go to: &lt;a href=&quot;https://github.com/jankae/LibreVNA/issues&quot;&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;LibreVNA issues&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Pull request are always welcome as this project is still in on-going development. If you have any proposal or feature, please create an issue or a pull request: &lt;a href=&quot;https://github.com/jankae/LibreVNA/issues&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;LibreVNA issues&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
              <property name="wordWrap">
               <bool>true</bool>

--- a/Software/PC_Application/appwindow.cpp
+++ b/Software/PC_Application/appwindow.cpp
@@ -50,28 +50,31 @@
 #include <QDebug>
 #include "CustomWidgets/jsonpickerdialog.h"
 #include <QCommandLineParser>
+#include "Util/app_common.h"
+#include "about.h"
 
 using namespace std;
+
+
+static const QString APP_VERSION = QString::number(FW_MAJOR) + "." +
+                                   QString::number(FW_MINOR) + "." +
+                                   QString::number(FW_PATCH);
+static const QString APP_GIT_HASH = QString(GITHASH);
 
 AppWindow::AppWindow(QWidget *parent)
     : QMainWindow(parent)
     , deviceActionGroup(new QActionGroup(this))
     , ui(new Ui::MainWindow)
     , server(nullptr)
+    , appVersion(APP_VERSION)
+    , appGitHash(APP_GIT_HASH)
 {
-    QCoreApplication::setOrganizationName("LibreVNA");
-    QCoreApplication::setApplicationName("LibreVNA-GUI");
-    auto commit = QString(GITHASH);
-    commit.truncate(7);
-    QCoreApplication::setApplicationVersion(QString::number(FW_MAJOR) + "." + QString::number(FW_MINOR)
-                                            + "." + QString::number(FW_PATCH) + FW_SUFFIX + " ("+ commit+")");
-
     qSetMessagePattern("%{time process}: [%{type}] %{message}");
 
 //    qDebug().setVerbosity(0);
     qDebug() << "Application start";
 
-    parser.setApplicationDescription("LibreVNA-GUI");
+    parser.setApplicationDescription(qlibrevnaApp->applicationName());
     parser.addHelpOption();
     parser.addVersionOption();
     parser.addOption(QCommandLineOption({"p","port"}, "Specify port to listen for SCPI commands", "port"));
@@ -202,12 +205,13 @@ AppWindow::AppWindow(QWidget *parent)
         // settings might have changed, update necessary stuff
 //        TraceXYPlot::updateGraphColors();
     });
+
     connect(ui->actionAbout, &QAction::triggered, [=](){
-        QMessageBox::about(this, "About", "More information: github.com/jankae/LibreVNA\n"
-                           "\nVersion: " + QCoreApplication::applicationVersion());
+        auto &a = About::getInstance();
+        a.about();
     });
 
-    setWindowTitle("LibreVNA-GUI");
+    setWindowTitle(qlibrevnaApp->applicationName() + " v"  + getAppVersion());
 
     setCorner(Qt::TopLeftCorner, Qt::LeftDockWidgetArea);
     setCorner(Qt::BottomLeftCorner, Qt::LeftDockWidgetArea);
@@ -695,4 +699,14 @@ QStackedWidget *AppWindow::getCentral() const
 Ui::MainWindow *AppWindow::getUi() const
 {
     return ui;
+}
+
+const QString& AppWindow::getAppVersion() const
+{
+    return appVersion;
+}
+
+const QString& AppWindow::getAppGitHash() const
+{
+    return appGitHash;
 }

--- a/Software/PC_Application/appwindow.h
+++ b/Software/PC_Application/appwindow.h
@@ -41,6 +41,9 @@ public:
     QStackedWidget *getCentral() const;
     Device *getDevice() const;
 
+    const QString& getAppVersion() const;
+    const QString& getAppGitHash() const;
+
 protected:
     void closeEvent(QCloseEvent *event) override;
 private slots:
@@ -95,6 +98,9 @@ private:
 
     SCPI scpi;
     TCPServer *server;
+
+    QString appVersion;
+    QString appGitHash;
 };
 
 #endif // VNA_H

--- a/Software/PC_Application/main.cpp
+++ b/Software/PC_Application/main.cpp
@@ -11,6 +11,8 @@
 
 #include <complex>
 
+static void setApplicationData();
+
 static QApplication *app;
 static AppWindow *window;
 
@@ -35,7 +37,16 @@ int main(int argc, char *argv[]) {
     }
     app = new QApplication(argc, argv_ext);
     window = new AppWindow;
+    setApplicationData();
     signal(SIGINT, sig_handler);
     app->exec();
     return 0;
+}
+
+static void setApplicationData()
+{
+    QCoreApplication::setOrganizationName("LibreVNA");
+    QCoreApplication::setApplicationName("LibreVNA-GUI");
+    QCoreApplication::setApplicationVersion(window->getAppVersion() + "-" +
+                                            window->getAppGitHash().left(9));
 }

--- a/Software/PC_Application/main.cpp
+++ b/Software/PC_Application/main.cpp
@@ -11,8 +11,6 @@
 
 #include <complex>
 
-static void setApplicationData();
-
 static QApplication *app;
 static AppWindow *window;
 
@@ -36,17 +34,12 @@ int main(int argc, char *argv[]) {
         }
     }
     app = new QApplication(argc, argv_ext);
+    QCoreApplication::setOrganizationName("LibreVNA");
+    QCoreApplication::setApplicationName("LibreVNA-GUI");
     window = new AppWindow;
-    setApplicationData();
+    QCoreApplication::setApplicationVersion(window->getAppVersion() + "-" +
+                                            window->getAppGitHash().left(9));
     signal(SIGINT, sig_handler);
     app->exec();
     return 0;
-}
-
-static void setApplicationData()
-{
-    QCoreApplication::setOrganizationName("LibreVNA");
-    QCoreApplication::setApplicationName("LibreVNA-GUI");
-    QCoreApplication::setApplicationVersion(window->getAppVersion() + "-" +
-                                            window->getAppGitHash().left(9));
 }


### PR DESCRIPTION
Greetings @jankae, I would like to improve what we currently have in About section and the way application was handling app version and revision to be able to show it in about. Here are the main points: 

- All methods about QCoreApplication as set{Organization,ApplicationName,ApplicationVersion} I guess can be declared in main.cpp and from there just grab the instance whenever we want to use those variables in project. As happens when we need to set `setApplicationDescription` and within `AboutDialog` class. I guess that probably this can be enhanced in the future if we can create a derivate class from QCoreApplication and move methods `getAppVersion, getAppGitHash` from `AppWindow` class. What are your thoughts? 

- With these changes introduced, I've added app version when app is launched. 

- About: I've added some text that will provide more information about the community that we have and also what would be the initial steps to start contributing to the project. There is something that I'm missing in terms of content or that's fine on your side? 

Bear in mind that this is my first time contributing, which I'm really happy to read your feedback on the implementation and refactor code if that is required. 

Thanks for all efforts and time you have invested on this since is quite amazing :D 
