### PR TITLE
gui: exits gracefully

### DIFF
--- a/Software/PC_Application/main.cpp
+++ b/Software/PC_Application/main.cpp
@@ -17,6 +17,7 @@ static AppWindow *window;
 void sig_handler(int s) {
     Q_UNUSED(s)
     window->close();
+    app->quit();
 }
 
 int main(int argc, char *argv[]) {
@@ -36,6 +37,6 @@ int main(int argc, char *argv[]) {
     app = new QApplication(argc, argv_ext);
     window = new AppWindow;
     signal(SIGINT, sig_handler);
-    app->exec();
-    return 0;
+    auto rc = app->exec();
+    return rc;
 }


### PR DESCRIPTION
When someone wants to launch application without no gui, i.e. when using SCPI server the following command can be used: 

`./LibreVNA --no-gui`

Which ends up as: 

```
 0.000: [info] Listening on port 19542
 0.018: [debug] Activating mode "Vector Network Analyzer"
 0.028: [debug] Updated device list, found 1
 0.028: [debug] Trying to connect to any device
 0.028: [debug] Attempting to connect to device...
 0.035: [info] USB connection established
 0.036: [debug] Receive thread started
 0.036: [info] Connected to "serial-id"
```

However, it may happen that another scpi server should be open, however, device is not specified. 

`./LibreVNA --no-gui <port2>`


```
 0.000: [info] Listening on port <port2>
 0.019: [debug] Activating mode "Vector Network Analyzer"
 0.027: [debug] Updated device list, found 1
 0.027: [debug] Trying to connect to any device
 0.027: [debug] Attempting to connect to device...
 0.035: [warning] "Failed to claim interface: \"Resource busy\" Maybe you are already connected to this device?"
 0.037: [warning] This plugin does not support propagateSizeHints()
 0.037: [warning] Failed to connect: Failed to claim interface: "Resource busy" Maybe you are already connected to this device?
 0.037: [debug] Disconnected device
```

At this point it seems like second application it's stuck or maybe developer wants just to exits application and start over again, however, when this application needs to be close gracefully it doesn't happen when using `SIGINT`. 

This commit fixes this situation so that when `SIGINT` is signaled, application can be exit with success. 
