### PR TITLE
gui: replot active mode when settings plot are updated

### DIFF
--- a/Software/PC_Application/SpectrumAnalyzer/spectrumanalyzer.cpp
+++ b/Software/PC_Application/SpectrumAnalyzer/spectrumanalyzer.cpp
@@ -69,6 +69,12 @@ SpectrumAnalyzer::SpectrumAnalyzer(AppWindow *window)
     traceXY->setYAxis(0, TraceXYPlot::YAxisType::Magnitude, false, false, -120,0,10);
     traceXY->setYAxis(1, TraceXYPlot::YAxisType::Disabled, false, true, 0,0,1);
 
+    connect(this, &SpectrumAnalyzer::graphColorsChanged, [=](){
+        for (auto p : TracePlot::getPlots()) {
+            p->updateGraphColors();
+        }
+    });
+
     central->setPlot(traceXY);
 
     // Create menu entries and connections
@@ -959,4 +965,9 @@ void SpectrumAnalyzer::StoreSweepSettings()
     s.setValue("SADetector", settings.Detector);
     s.setValue("SAAveraging", averages);
     s.setValue("SASignalID", static_cast<bool>(settings.SignalID));
+}
+
+void SpectrumAnalyzer::updateGraphColors()
+{
+    emit graphColorsChanged();
 }

--- a/Software/PC_Application/SpectrumAnalyzer/spectrumanalyzer.h
+++ b/Software/PC_Application/SpectrumAnalyzer/spectrumanalyzer.h
@@ -24,6 +24,9 @@ public:
     virtual nlohmann::json toJSON() override;
     virtual void fromJSON(nlohmann::json j) override;
 
+    void updateGraphColors();
+
+
 private:
     enum class Window {
         None = 0,
@@ -117,6 +120,7 @@ signals:
     void NormalizationLevelChanged(double level);
 
     void averagingChanged(unsigned int averages);
+    void graphColorsChanged();
 };
 
 #endif // VNA_H

--- a/Software/PC_Application/Traces/traceplot.cpp
+++ b/Software/PC_Application/Traces/traceplot.cpp
@@ -391,3 +391,8 @@ void TracePlot::markerRemoved(Marker *m)
     disconnect(m, &Marker::symbolChanged, this, &TracePlot::triggerReplot);
     triggerReplot();
 }
+
+void TracePlot::updateGraphColors()
+{
+    replot();
+}

--- a/Software/PC_Application/Traces/traceplot.h
+++ b/Software/PC_Application/Traces/traceplot.h
@@ -28,6 +28,9 @@ public:
 
     static std::set<TracePlot *> getPlots();
 
+public slots:
+    void updateGraphColors();
+
 signals:
     void doubleClicked(QWidget *w);
     void deleted(TracePlot*);

--- a/Software/PC_Application/Traces/tracesmithchart.h
+++ b/Software/PC_Application/Traces/tracesmithchart.h
@@ -18,6 +18,7 @@ public:
     virtual void fromJSON(nlohmann::json j) override;
 public slots:
     void axisSetupDialog();
+
 protected:
     static constexpr double ReferenceImpedance = 50.0;
     static constexpr double screenUsage = 0.9;

--- a/Software/PC_Application/VNA/vna.cpp
+++ b/Software/PC_Application/VNA/vna.cpp
@@ -75,6 +75,7 @@ VNA::VNA(AppWindow *window)
 
     auto tracesmith1 = new TraceSmithChart(traceModel);
     tracesmith1->enableTrace(tS11, true);
+
     auto tracesmith2 = new TraceSmithChart(traceModel);
     tracesmith2->enableTrace(tS22, true);
 
@@ -82,6 +83,12 @@ VNA::VNA(AppWindow *window)
     traceXY1->enableTrace(tS12, true);
     auto traceXY2 = new TraceXYPlot(traceModel);
     traceXY2->enableTrace(tS21, true);
+
+    connect(this, &VNA::graphColorsChanged, [=](){
+        for (auto p : TracePlot::getPlots()) {
+            p->updateGraphColors();
+        }
+    });
 
     connect(&traceModel, &TraceModel::requiredExcitation, this, &VNA::ExcitationRequired);
 
@@ -1116,4 +1123,9 @@ void VNA::EnableDeembedding(bool enable)
     enableDeembeddingAction->blockSignals(true);
     enableDeembeddingAction->setChecked(enable);
     enableDeembeddingAction->blockSignals(false);
+}
+
+void VNA::updateGraphColors()
+{
+    emit graphColorsChanged();
 }

--- a/Software/PC_Application/VNA/vna.h
+++ b/Software/PC_Application/VNA/vna.h
@@ -26,6 +26,9 @@ public:
     // Only save/load user changeable stuff, no need to save the widgets/mode name etc.
     virtual nlohmann::json toJSON() override;
     virtual void fromJSON(nlohmann::json j) override;
+
+    void updateGraphColors();
+
 private slots:
     void NewDatapoint(Protocol::Datapoint d);
     void StartImpedanceMatching();
@@ -48,8 +51,10 @@ private slots:
     void ApplyCalibration(Calibration::Type type);
     void StartCalibrationMeasurement(Calibration::Measurement m);
 
+
 signals:
     void CalibrationMeasurementComplete(Calibration::Measurement m);
+    void graphColorsChanged();
 
 private:
     bool CalibrationMeasurementActive() { return calWaitFirst || calMeasuring; }

--- a/Software/PC_Application/appwindow.cpp
+++ b/Software/PC_Application/appwindow.cpp
@@ -202,8 +202,15 @@ AppWindow::AppWindow(QWidget *parent)
                 StartTCPServer(p.General.SCPI.port);
             }
         }
-        // settings might have changed, update necessary stuff
-//        TraceXYPlot::updateGraphColors();
+        auto active = Mode::getActiveMode();
+
+        if(active == spectrumAnalyzer) {
+            spectrumAnalyzer->updateGraphColors();
+        }
+        else if (active == vna) {
+             vna->updateGraphColors();
+        }
+
     });
 
     connect(ui->actionAbout, &QAction::triggered, [=](){


### PR DESCRIPTION
@jankae, 

The following commit tries to propagate as quickly as possible new plot settings in active mode. This will avoid: 

- Swap between mode in order to refresh
- Update plot portions while paint events are being generated. See example below. 

![settings-not-updated](https://user-images.githubusercontent.com/1287883/123729734-db765e00-d86b-11eb-9a64-9940110c4772.png)

If there is a better way to handle this, just let me know and I'll be really happy to refactor it. I guess it was an attempt before to achieve this? 
