### PR TITLE
gui: set individual plot as full screen when double clicked

### DIFF
--- a/Software/PC_Application/CustomWidgets/tilewidget.h
+++ b/Software/PC_Application/CustomWidgets/tilewidget.h
@@ -36,6 +36,7 @@ public slots:
 private slots:
     void on_bSmithchart_clicked();
     void on_bXYplot_clicked();
+    void on_plotDoubleClicked();
     void traceDeleted(TracePlot *t);
 
 private:
@@ -43,12 +44,16 @@ private:
     void split();
     void setContent(TracePlot *plot);
     void setChild();
+    TileWidget* findRootTile();
+    void setFullScreen();
+    TracePlot *fullScreenPlot;
     Ui::TileWidget *ui;
     QSplitter *splitter;
     bool isSplit;
     TileWidget *parent;
     TileWidget *child1, *child2;
     bool hasContent;
+    bool isFullScreen;
     TracePlot *content;
     TraceModel &model;
 };

--- a/Software/PC_Application/CustomWidgets/tilewidget.ui
+++ b/Software/PC_Application/CustomWidgets/tilewidget.ui
@@ -200,6 +200,7 @@
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="ContentFullScreenMode"/>
      <widget class="QWidget" name="ContentPage"/>
     </widget>
    </item>


### PR DESCRIPTION
The following commit features to set specific plot as full screen
if double clicked event is triggered while mouse is over that
particular plot.

This becomes handy if you are interested in a particular traces over
that plot and want to inspect it in more detail.

To come back and show all four plots, another double clicked event should be trigger. I guess it's pretty intuitive. 

@jankae what do you think? 

![traceplot-fs](https://user-images.githubusercontent.com/1287883/124206759-5a60d600-daba-11eb-9d1f-38b8b86c9282.png)
