### PR TITLE
actions: increase granularity in artifacts, automate releases

### DIFF
--- a/.github/workflows/Release_tag_stable.yml
+++ b/.github/workflows/Release_tag_stable.yml
@@ -1,27 +1,23 @@
-name: Build
+name: Upload release for tag stable
 
 on:
   push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
+
   PC_Application_Ubuntu:
     runs-on: ubuntu-18.04
+    outputs:
+      upload_url: ${{ steps.bump_release.outputs.upload_url }} 
     steps:
       - uses: actions/checkout@v1
 
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libusb-1.0-0-dev qt5-default qt5-qmake qtbase5-dev
-
-      - name: Get build timestamp
-        id: id_date
-        run: echo "::set-output name=timestamp::$(date +%Y-%m-%d-%H-%M-%S)"
+          sudo apt-get install -y libusb-1.0-0-dev qt5-default qt5-qmake qtbase5-dev zip
 
       - name: Get app version
         id: id_version
@@ -30,24 +26,43 @@ jobs:
           fw_major=`grep -oP '(?<=FW_MAJOR=)[0-9]+' LibreVNA-GUI.pro`
           fw_minor=`grep -oP '(?<=FW_MINOR=)[0-9]+' LibreVNA-GUI.pro`
           fw_patch=`grep -oP '(?<=FW_PATCH=)[0-9]+' LibreVNA-GUI.pro` 
-          echo "::set-output name=app_version::v$fw_major.$fw_minor.$fw_patch-${{steps.id_date.outputs.timestamp}}"
+          echo "::set-output name=app_version::v$fw_major.$fw_minor.$fw_patch"
 
       - name: Build application
         run: |
           cd Software/PC_Application
           qmake LibreVNA-GUI.pro
           make -j9
+          zip LibreVNA-GUI.zip LibreVNA-GUI
         shell: bash
 
-      - name: Upload artifact
-        env: 
+      - name: Bump release page
+        id: bump_release
+        uses: actions/create-release@v1
+        env:
           LIBREVNA_VERSION: "${{steps.id_version.outputs.app_version}}"
-        uses: actions/upload-artifact@v2
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          name: LibreVNA-GUI-Ubuntu-${{env.LIBREVNA_VERSION}}
-          path: Software/PC_Application/LibreVNA-GUI
+          tag_name: ${{env.LIBREVNA_VERSION}}
+          release_name: ${{env.LIBREVNA_VERSION}}
+          body: |
+              See [CHANGELOG](https://github.com/${{github.repository}}/blob/${{env.LIBREVNA_VERSION}}/CHANGELOG.md) for more information.
+          draft: false
+          prerelease: false
+
+      - name: 'Upload release asset'
+        uses: actions/upload-release-asset@v1
+        env:
+          LIBREVNA_VERSION: "${{steps.id_version.outputs.app_version}}"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.bump_release.outputs.upload_url }}
+          asset_path: ./Software/PC_Application/LibreVNA-GUI.zip
+          asset_name: LibreVNA-GUI-Ubuntu-${{env.LIBREVNA_VERSION}}.zip
+          asset_content_type: application/tar+gzip
           
   PC_Application_Windows:
+    needs: PC_Application_Ubuntu
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v1
@@ -67,11 +82,6 @@ jobs:
           Xcopy /E /I /Y libusb\MinGW64\static Software\PC_Application
         shell: cmd
 
-      - name: Get build timestamp
-        shell: msys2 {0}
-        id: id_date
-        run: echo "::set-output name=timestamp::$(date +%Y-%m-%d-%H-%M-%S)"
-
       - name: Get app version
         id: id_version
         shell: msys2 {0}
@@ -80,7 +90,7 @@ jobs:
           fw_major=`grep -oP '(?<=FW_MAJOR=)[0-9]+' LibreVNA-GUI.pro`
           fw_minor=`grep -oP '(?<=FW_MINOR=)[0-9]+' LibreVNA-GUI.pro`
           fw_patch=`grep -oP '(?<=FW_PATCH=)[0-9]+' LibreVNA-GUI.pro` 
-          echo "::set-output name=app_version::v$fw_major.$fw_minor.$fw_patch-${{steps.id_date.outputs.timestamp}}"
+          echo "::set-output name=app_version::v$fw_major.$fw_minor.$fw_patch"
 
       - name: Build application
         run: |
@@ -99,16 +109,27 @@ jobs:
           copy "..\..\..\..\Qt\5.15.1\mingw81_64\bin\libstdc++-6.dll" .
           copy ..\..\..\..\Qt\5.15.1\mingw81_64\bin\Qt5OpenGL.dll .
         shell: cmd
-        
-      - name: Upload
-        uses: actions/upload-artifact@v2
+
+      - name: Zip app
+        shell: cmd
         env: 
           LIBREVNA_VERSION: "${{steps.id_version.outputs.app_version}}"
-        with:
-          name: GUI_Windows-${{env.LIBREVNA_VERSION}}
-          path: Software/PC_Application/release
+        run: |
+          7z a LibreVNA-GUI_Windows-${{env.LIBREVNA_VERSION}}.zip ./Software/PC_Application/release
 
+      - name: 'Upload release asset'
+        uses: actions/upload-release-asset@v1
+        env:
+          LIBREVNA_VERSION: "${{steps.id_version.outputs.app_version}}"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.PC_Application_Ubuntu.outputs.upload_url }}
+          asset_path: ./LibreVNA-GUI_Windows-${{env.LIBREVNA_VERSION}}.zip
+          asset_name: LibreVNA-GUI_Windows-${{env.LIBREVNA_VERSION}}.zip
+          asset_content_type: application/tar+gzip
+          
   PC_Application_OSX:
+    needs: PC_Application_Ubuntu
     runs-on: macos-10.15
     steps:
       - uses: actions/checkout@v1
@@ -121,10 +142,6 @@ jobs:
         run: |
           echo "/usr/local/opt/qt@5/bin" >> $GITHUB_PATH
           
-      - name: Get build timestamp
-        id: id_date
-        run: echo "::set-output name=timestamp::$(date +%Y-%m-%d-%H-%M-%S)"
-
       - name: Get app version
         id: id_version
         run: |
@@ -132,7 +149,7 @@ jobs:
           fw_major=`pcregrep -o '(?<=FW_MAJOR=)[0-9]+' LibreVNA-GUI.pro`
           fw_minor=`pcregrep -o '(?<=FW_MINOR=)[0-9]+' LibreVNA-GUI.pro`
           fw_patch=`pcregrep -o '(?<=FW_PATCH=)[0-9]+' LibreVNA-GUI.pro` 
-          echo "::set-output name=app_version::v$fw_major.$fw_minor.$fw_patch-${{steps.id_date.outputs.timestamp}}"
+          echo "::set-output name=app_version::v$fw_major.$fw_minor.$fw_patch"
 
       - name: Build application
         run: |
@@ -143,15 +160,19 @@ jobs:
           zip -ry LibreVNA-GUI.zip LibreVNA-GUI.app
         shell: bash
 
-      - name: Upload artifact
-        env: 
+      - name: 'Upload release asset'
+        uses: actions/upload-release-asset@v1
+        env:
           LIBREVNA_VERSION: "${{steps.id_version.outputs.app_version}}"
-        uses: actions/upload-artifact@v2
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          name: LibreVNA-GUI-OSX-${{env.LIBREVNA_VERSION}}
-          path: Software/PC_Application/LibreVNA-GUI.zip
+          upload_url: ${{ needs.PC_Application_Ubuntu.outputs.upload_url }}
+          asset_path: ./Software/PC_Application/LibreVNA-GUI.zip
+          asset_name: LibreVNA-GUI-OSX-${{env.LIBREVNA_VERSION}}.zip
+          asset_content_type: application/tar+gzip
           
   Embedded_Firmware:
+    needs: PC_Application_Ubuntu
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
@@ -160,10 +181,6 @@ jobs:
         run: |
           sudo apt-get install -y gcc-arm-none-eabi binutils-arm-none-eabi
         
-      - name: Get build timestamp
-        id: id_date
-        run: echo "::set-output name=timestamp::$(date +%Y-%m-%d-%H-%M-%S)"
-
       - name: Get app version
         id: id_version
         run: |
@@ -172,7 +189,7 @@ jobs:
           fw_minor=`grep -oP '(?<=FW_MINOR=)[0-9]+' Makefile`
           fw_patch=`grep -oP '(?<=FW_PATCH=)[0-9]+' Makefile`
           hw_revision=`grep "DHW_REVISION=" Makefile | sed "s/-DHW_REVISION=\"'//" | sed "sr'\" [\]rr"`
-          echo "::set-output name=app_version::hw-rev-$hw_revision-v$fw_major.$fw_minor.$fw_patch-${{steps.id_date.outputs.timestamp}}"
+          echo "::set-output name=app_version::hw-rev-$hw_revision-v$fw_major.$fw_minor.$fw_patch"
 
       - name: Build application
         run: |
@@ -186,12 +203,20 @@ jobs:
           python3 AssembleFirmware.py
         shell: bash
 
-      - name: Upload
-        uses: actions/upload-artifact@v2
+      - name: Zip firmware
         env: 
           LIBREVNA_VERSION: "${{steps.id_version.outputs.app_version}}"
+        run: |
+          zip EmbeddedFirmware-${{env.LIBREVNA_VERSION}}.zip VNA_embedded.elf combined.vnafw
+        shell: bash
+        
+      - name: 'Upload release asset'
+        uses: actions/upload-release-asset@v1
+        env:
+          LIBREVNA_VERSION: "${{steps.id_version.outputs.app_version}}"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          name: EmbeddedFirmware-${{env.LIBREVNA_VERSION}}
-          path: |
-            VNA_embedded.elf
-            combined.vnafw
+          upload_url: ${{ needs.PC_Application_Ubuntu.outputs.upload_url }}
+          asset_path: ./EmbeddedFirmware-${{env.LIBREVNA_VERSION}}.zip
+          asset_name: EmbeddedFirmware-${{env.LIBREVNA_VERSION}}.zip
+          asset_content_type: application/tar+gzip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## v1.1.2
+
+- Software:
+  - Fix parsing of calibration kit settings
+
+No changes have been made to the embedded software, updating the firmware on the LibreVNA is not required.


### PR DESCRIPTION
Hi @jankae 

After a couple of days I come up with some suggestions in a way LibreVNA artifacts are delivered for every push to mainstream and also whenever a new release is coming up. In PR there will be a couple of things that I need to fix before actually being merged to master and I would like to here your thoughts about this. 

So far, artifacts are delivered using same name. But I think that would be great if community can download them and have unique version names along with it. Based on this, I propose to add:

- From `EmbeddedFirmware` to `EmbeddedFirmware-hw-rev-B-v1.1.1-2021-07-07-12-36`
Name includes following meta data:

1. Hardware revision: B
2. Firmware version
3. Year, month, day, hour, minute at which this build was executed

- From `GUI_Windows` to `GUI_Windows-v1.1.2-2021-07-07-12-33`
Meta data included:

1. OS
2. Application version
3. Year, month, day, hour, minute at which this build was executed

The same applies for the other gui applications, they only differ in OS. 

The benefits of using this approach is that, for every commit change based on trigger, artifacts will be unique. In this way, if anyone want to test several versions, it will be easy to identify which zip contains what version. 

I thought about setting timestamp but I guess at this point in the project, as build are not happening with such frequency, then it's only valid to limit up to minutes. 

About hardware revision, I guess this is really important, seems community can clearly identify with which board revision the firmware works.

[An example of this can be seen in this build. ](https://github.com/sophiekovalevsky/LibreVNA/actions/runs/1008016087#artifacts)

On the other hand, about releases I think we can add enhance it using the following. 

1. Creating another build that will only be triggered whenever tags are release. This build will be in charge of populating required information from `CHANGELOG.md` to release page and also to generate releases artifacts. 
2. A `CHANGELOG.md` creation is suggested, I've created one that you can see [here.](https://github.com/sophiekovalevsky/LibreVNA/blob/include-version-artifacts/CHANGELOG.md) using https://github.com/CookPete/auto-changelog I guess that even if this tool it's not used, LibreVNA can start to have this file in a way to point out community whenever they want to see an overview of what changes have been made in application over the entire release cycle, also this would be included in the app itself within same section as `About` is up the moment. What are your thoughts on this? 
3. For artifacts releases then we can remove date related meta data.

The example can be seen [here](https://github.com/sophiekovalevsky/LibreVNA/releases/tag/v1.1.2). 

I'm really open to read your ideas and if this solution fits within LibreVNA project.

