### PR TITLE
fw/hardware: disable debug pins

### DIFF
--- a/Software/VNA_embedded/Application/Hardware.cpp
+++ b/Software/VNA_embedded/Application/Hardware.cpp
@@ -75,7 +75,7 @@ void HW::Work() {
 }
 
 bool HW::Init() {
-#ifdef USE_DEBUG_PINS
+#if USE_DEBUG_PINS
 	// initialize debug pins
 	GPIO_InitTypeDef gpio;
 	gpio.Pin = DEBUG1_PIN;

--- a/Software/VNA_embedded/Application/Hardware.hpp
+++ b/Software/VNA_embedded/Application/Hardware.hpp
@@ -7,9 +7,9 @@
 #include "max2871.hpp"
 #include "Si5351C.hpp"
 
-#define USE_DEBUG_PINS
+#define USE_DEBUG_PINS	0
 
-#ifdef USE_DEBUG_PINS
+#if USE_DEBUG_PINS
 #define DEBUG1_GPIO		GPIOA
 #define DEBUG1_PIN		GPIO_PIN_13
 #define DEBUG2_GPIO		GPIOA


### PR DESCRIPTION
When USE_DEBUG_PINS is enabled and debug session is open, their pin initialization makes debug probe to lost session. As these pins are not used, let's disable it by default.

