### PR TITLE
Add a white background for each Block Diagram

### DIFF
--- a/Documentation/DeveloperInfo/DigitalBlockdiagram.svg
+++ b/Documentation/DeveloperInfo/DigitalBlockdiagram.svg
@@ -292,6 +292,7 @@
 </symbol>
 </g>
 </defs>
+<rect width="100%" height="100%" fill="white"/>
 <g id="surface1">
 <path style="fill:none;stroke-width:0.3985;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%,0%,0%);stroke-opacity:1;stroke-miterlimit:10;" d="M -127.562563 -28.347906 L -42.519594 -28.347906 L -42.519594 28.347406 L -127.562563 28.347406 Z M -127.562563 -28.347906 " transform="matrix(1,0,0,-1,217.461,137.406)"/>
 <g style="fill:rgb(0%,0%,0%);fill-opacity:1;">

--- a/Documentation/DeveloperInfo/PowerBlockdiagram.svg
+++ b/Documentation/DeveloperInfo/PowerBlockdiagram.svg
@@ -244,6 +244,7 @@
 </symbol>
 </g>
 </defs>
+<rect width="100%" height="100%" fill="white"/>
 <g id="surface1">
 <path style="fill:none;stroke-width:0.3985;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%,0%,0%);stroke-opacity:1;stroke-miterlimit:10;" d="M -20.492 -12.702 L 20.492375 -12.702 L 20.492375 12.700344 L -20.492 12.700344 Z M -20.492 -12.702 " transform="matrix(1,0,0,-1,103.367,29.173)"/>
 <g style="fill:rgb(0%,0%,0%);fill-opacity:1;">

--- a/Documentation/DeveloperInfo/RFBlockdiagram.svg
+++ b/Documentation/DeveloperInfo/RFBlockdiagram.svg
@@ -280,6 +280,7 @@
 </symbol>
 </g>
 </defs>
+<rect width="100%" height="100%" fill="white"/>
 <g id="surface1">
 <path style="fill:none;stroke-width:0.3985;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(0%,0%,0%);stroke-opacity:1;stroke-miterlimit:10;" d="M -116.319969 -6.045625 L -93.343406 -6.045625 L -93.343406 6.044219 L -116.319969 6.044219 Z M -116.319969 -6.045625 " transform="matrix(1,0,0,-1,208.902,194.72)"/>
 <g style="fill:rgb(0%,0%,0%);fill-opacity:1;">


### PR DESCRIPTION
The block diagrams in the Readme were very difficult to view while using Github's dark theme. See screenshot:
![image](https://user-images.githubusercontent.com/1299430/135859480-001ebafe-07ff-4625-b09e-49b9b46f46d2.png)
By adding a white background to each block diagram, they can be viewed clearly:
![image](https://user-images.githubusercontent.com/1299430/135859563-0b598acd-5302-455a-838c-e0d853228221.png)
