### PR TITLE
gui: implement status bar based upon device state

### DIFF
--- a/Software/PC_Application/appwindow.h
+++ b/Software/PC_Application/appwindow.h
@@ -61,7 +61,17 @@ private slots:
     nlohmann::json SaveSetup();
     void LoadSetup(nlohmann::json j);
 private:
+
+    enum DeviceStatusBar {
+        Connected,
+        Updated,
+        Disconnected,
+    };
+
     void DeviceConnectionLost();
+
+    void SetupStatusBar();
+    void UpdateStatusBar(DeviceStatusBar status);
     void CreateToolbars();
     void SetupSCPI();
     void StartTCPServer(int port);


### PR DESCRIPTION
When device has not been connected for the first time, status bar doesn't any information.

This implementation tries to encapsulate changes required on several widgets associated with status bar based upon device state
whether this has been connected or not.

I'm open to receive any feedback as always. :D