### PR TITLE
gui/traces: prevent out of range when marker is added on smith chart

### DIFF
--- a/Software/PC_Application/Traces/tracesmithchart.cpp
+++ b/Software/PC_Application/Traces/tracesmithchart.cpp
@@ -97,8 +97,9 @@ QPoint TraceSmithChart::markerToPixel(Marker *m)
 double TraceSmithChart::nearestTracePoint(Trace *t, QPoint pixel, double *distance)
 {
     double closestDistance = numeric_limits<double>::max();
-    unsigned int closestIndex = 0;
-    for(unsigned int i=0;i<t->size();i++) {
+    double closestXpos = 0;
+    auto samples = t->size();
+    for(unsigned int i=0;i<samples;i++) {
         auto data = t->sample(i);
         auto plotPoint = dataToPixel(data);
         if (plotPoint.isNull()) {
@@ -109,13 +110,13 @@ double TraceSmithChart::nearestTracePoint(Trace *t, QPoint pixel, double *distan
         unsigned int distance = diff.x() * diff.x() + diff.y() * diff.y();
         if(distance < closestDistance) {
             closestDistance = distance;
-            closestIndex = i;
+            closestXpos = t->sample(i).x;
         }
     }
     if(distance) {
         *distance = closestDistance;
     }
-    return t->sample(closestIndex).x;
+    return closestXpos;
 }
 
 bool TraceSmithChart::xCoordinateVisible(double x)


### PR DESCRIPTION
This situation probably won't happen too often and it's the following: 

- GUI is opened for the first time
- No device has been connected yet
- At least one trace is enabled on smith chart instance and a "Add marker here" is triggered

GUI crashes with: 
```terminate called after throwing an instance of 'std::out_of_range'
  what():  vector::_M_range_check: __n (which is 0) >= this->size() (which is 0)
```

This happens when at:
https://github.com/jankae/LibreVNA/blob/09366d73ccf377c7197bd36d8cbae4385415d172/Software/PC_Application/Traces/tracesmithchart.cpp#L118

I fixed by assigning closes x position within loop so we can be sure index will be in range. 

