### PR TITLE
gui/math: return data point only within range

### DIFF
--- a/Software/PC_Application/Traces/Math/tracemath.cpp
+++ b/Software/PC_Application/Traces/Math/tracemath.cpp
@@ -84,7 +84,11 @@ TraceMath::TypeInfo TraceMath::getInfo(TraceMath::Type type)
 
 TraceMath::Data TraceMath::getSample(unsigned int index)
 {
-    return data.at(index);
+    TraceMath::Data d;
+    if (data.size() >= 1) {
+        d = data.at(index);
+    }
+    return d;
 }
 
 double TraceMath::getStepResponse(unsigned int index)


### PR DESCRIPTION
I keep doing a great happy LibreVNA programming weekend :) and I found another thing we could improve. First, steps to reproduce: 

- Launch LibreVNA gui and do not attach any hardware
- On VNA mode, add marker throughout Marker Dock. By default it will create marker on smith chart plot associated to S11. 
- On trace column within Marker Dock, select S12.
- Generate a left button event within XY plot where S12 resides. 
- Application crashes.

How to fix it? 

I'm not sure if this fix it's the most affordable solution and I'm open to suggestions. I guess what it's happening is an overflow when trying to acquire a data point and as this trace is empty.

Over the quick tests I made, seems that app works fine unless I'm missing something else to test to.