### PR TITLE
scripts/ci: implement code style

### DIFF
--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -1,0 +1,24 @@
+name: Lint 
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  linter:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v1 
+
+    - name: Install dependencies 
+      run: |
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+        sudo add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main"
+        sudo apt-get update && sudo apt-get install --no-install-recommends -y clang-format-13
+    - name: Lint 
+      run: |
+        bash ./Software/PC_Application/Scripts/linter.sh -l --dry-run 

--- a/Software/PC_Application/.clang-format
+++ b/Software/PC_Application/.clang-format
@@ -1,0 +1,72 @@
+---
+Language:        Cpp
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: DontAlign
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: InlineOnly
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakStringLiterals: true
+ColumnLimit:     100
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
+DisableFormat:   false
+FixNamespaceComments: true
+ForEachMacros:   
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IndentCaseLabels: true
+IndentPPDirectives: AfterHash
+IndentWidth:     2
+IndentWrappedFunctionNames: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 3
+NamespaceIndentation: Inner
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: true
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  true
+SpacesInContainerLiterals: true
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto # Seems cpp17 is not supported
+TabWidth:        2
+UseTab:          ForContinuationAndIndentation

--- a/Software/PC_Application/Scripts/linter.sh
+++ b/Software/PC_Application/Scripts/linter.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -e
+
+PROJECT_DIR="${BASH_SOURCE%/*/*}"
+
+SCRIPT_DIR="Software/PC_Application"
+
+DRY_RUN=0
+checkSources()
+{
+	START=$(date +%s)
+	local DIRS=(
+		.
+		Calibration
+		CustomWidgets
+		Device
+		Generator
+		SpectrumAnalyzer
+		Tools
+		Traces
+		Traces/Marker
+		Traces/Math
+		Traces/Math/parser
+		Util
+		VNA
+		VNA/Deembedding
+	)
+
+	local ARGS=""
+	if [ ${DRY_RUN} -eq 1 ]; then
+		ARGS+="--dry-run";
+		echo "Applying dry run"
+	fi
+	for dir in "${DIRS[@]}"
+	do
+		find $PROJECT_DIR/$dir -maxdepth 1 -type f -regex '.*\.\(cpp\|h\)' -exec clang-format -style=file $ARGS -i {} \;
+	done
+	ELAPSED=$(date +%s)
+	DELTA_TIME=$((ELAPSED-START))
+
+	echo "linting took: $DELTA_TIME seconds to complete"
+}
+
+
+opstr+="l-:";
+
+while getopts "${opstr}" OPTION; do
+	case $OPTION in
+		l)  LINT=1; ;;
+		-) case ${OPTARG} in
+			dry-run) DRY_RUN=1; ;;
+		   esac;;
+		*) ;;
+	esac
+done
+
+if [ "${LINT}" == 1 ]; then
+	checkSources;
+fi
+
+
+exit 0


### PR DESCRIPTION
This is a starting point thinking that maybe in the future other hardware engineers may want to contribute. Why if we don´t start to verify that every changes are made be compliant with some code format. Currently, I tested this only for the pc application but I can imagine that can be extrapolated to the firmware side. 

@jankae, what do you think? 

Seems like clang-format is not able to use `c++17` though

