### PR TITLE
app/main/device: move metatypes to device

### DIFF
--- a/Software/PC_Application/Device/device.cpp
+++ b/Software/PC_Application/Device/device.cpp
@@ -234,6 +234,14 @@ Device::~Device()
     }
 }
 
+void Device::RegisterTypes()
+{
+    qRegisterMetaType<Protocol::Datapoint>("Datapoint");
+    qRegisterMetaType<Protocol::ManualStatusV1>("ManualV1");
+    qRegisterMetaType<Protocol::SpectrumAnalyzerResult>("SpectrumAnalyzerResult");
+    qRegisterMetaType<Protocol::AmplitudeCorrectionPoint>("AmplitudeCorrection");
+}
+
 bool Device::SendPacket(const Protocol::PacketInfo& packet, std::function<void(TransmissionResult)> cb, unsigned int timeout)
 {
     Transmission t;

--- a/Software/PC_Application/Device/device.h
+++ b/Software/PC_Application/Device/device.h
@@ -58,6 +58,8 @@ public:
     // connect to a VNA device. If serial is specified only connecting to this device, otherwise to the first one found
     Device(QString serial = QString());
     ~Device();
+
+    static void RegisterTypes();
     bool SendPacket(const Protocol::PacketInfo& packet, std::function<void(TransmissionResult)> cb = nullptr, unsigned int timeout = 500);
     bool Configure(Protocol::SweepSettings settings, std::function<void(TransmissionResult)> cb = nullptr);
     bool Configure(Protocol::SpectrumAnalyzerSettings settings, std::function<void(TransmissionResult)> cb = nullptr);

--- a/Software/PC_Application/appwindow.cpp
+++ b/Software/PC_Application/appwindow.cpp
@@ -234,11 +234,6 @@ AppWindow::AppWindow(QWidget *parent)
     // Set default mode
     vna->activate();
 
-    qRegisterMetaType<Protocol::Datapoint>("Datapoint");
-    qRegisterMetaType<Protocol::ManualStatusV1>("ManualV1");
-    qRegisterMetaType<Protocol::SpectrumAnalyzerResult>("SpectrumAnalyzerResult");
-    qRegisterMetaType<Protocol::AmplitudeCorrectionPoint>("AmplitudeCorrection");
-
     auto pref = Preferences::getInstance();
     if(pref.Startup.UseSetupFile) {
         LoadSetup(pref.Startup.SetupFile);

--- a/Software/PC_Application/main.cpp
+++ b/Software/PC_Application/main.cpp
@@ -1,5 +1,6 @@
 #include "appwindow.h"
 #include <QtWidgets/QApplication>
+#include "Device/device.h"
 #ifdef Q_OS_UNIX
 #include <signal.h>
 #endif
@@ -22,6 +23,8 @@ int main(int argc, char *argv[]) {
     window = new AppWindow;
     QCoreApplication::setApplicationVersion(window->getAppVersion() + "-" +
                                             window->getAppGitHash().left(9));
+
+    Device::RegisterTypes();
 
 #ifdef Q_OS_UNIX
     signal(SIGINT, tryExitGracefully);


### PR DESCRIPTION
Whenever meta types are registered, it make sense to have a static method class as close as possible where `Q_DECLARE_METATYPE` is used. 

I can imagine in the future that possible classes may required to do same, hence, would be convinient to called those static method in `main` rather than in `AppWindow` class. 


