### PR TITLE
main/app: move message pattern to main

### DIFF
--- a/Software/PC_Application/appwindow.cpp
+++ b/Software/PC_Application/appwindow.cpp
@@ -75,8 +75,6 @@ AppWindow::AppWindow(QWidget *parent)
     , appVersion(APP_VERSION)
     , appGitHash(APP_GIT_HASH)
 {
-    qSetMessagePattern("%{time process}: [%{type}] %{message}");
-
 //    qDebug().setVerbosity(0);
     qDebug() << "Application start";
 

--- a/Software/PC_Application/main.cpp
+++ b/Software/PC_Application/main.cpp
@@ -17,6 +17,9 @@ static void tryExitGracefully(int s) {
 #endif
 
 int main(int argc, char *argv[]) {
+
+    qSetMessagePattern("%{time process}: [%{type}] %{message}");
+
     app = new QApplication(argc, argv);
     QCoreApplication::setOrganizationName("LibreVNA");
     QCoreApplication::setApplicationName("LibreVNA-GUI");


### PR DESCRIPTION
Probably we can move it to`main` because, there this doesn´t depend on `AppWindow` instances. 