### PR TITLE
scpi/app: unify result name

### DIFF
--- a/Software/PC_Application/Generator/generator.cpp
+++ b/Software/PC_Application/Generator/generator.cpp
@@ -70,10 +70,10 @@ void Generator::setupSCPI()
     add(new SCPICommand("FREQuency", [=](QStringList params) -> QString {
         unsigned long long newval;
         if(!SCPI::paramToULongLong(params, 0, newval)) {
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         } else {
             central->setFrequency(newval);
-            return "";
+            return SCPI::getResultName(SCPI::Result::Empty);
         }
     }, [=](QStringList) -> QString {
         return QString::number(central->getDeviceStatus().frequency);
@@ -82,10 +82,10 @@ void Generator::setupSCPI()
         double newval;
         if(!SCPI::paramToDouble(params, 0, newval)) {
 
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         } else {
             central->setLevel(newval);
-            return "";
+            return SCPI::getResultName(SCPI::Result::Empty);
         }
     }, [=](QStringList) -> QString {
         return QString::number(central->getDeviceStatus().cdbm_level / 100.0);
@@ -93,10 +93,10 @@ void Generator::setupSCPI()
     add(new SCPICommand("PORT", [=](QStringList params) -> QString {
         unsigned long long newval;
         if(!SCPI::paramToULongLong(params, 0, newval) || newval > 2) {
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         } else {
             central->setPort(newval);
-            return "";
+            return SCPI::getResultName(SCPI::Result::Empty);
         }
     }, [=](QStringList) -> QString {
         return QString::number(central->getDeviceStatus().activePort);

--- a/Software/PC_Application/SpectrumAnalyzer/spectrumanalyzer.cpp
+++ b/Software/PC_Application/SpectrumAnalyzer/spectrumanalyzer.cpp
@@ -837,10 +837,10 @@ void SpectrumAnalyzer::SetupSCPI()
     scpi_freq->add(new SCPICommand("SPAN", [=](QStringList params) -> QString {
         unsigned long long newval;
         if(!SCPI::paramToULongLong(params, 0, newval)) {
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         } else {
             SetSpan(newval);
-            return "";
+            return SCPI::getResultName(SCPI::Result::Empty);
         }
     }, [=](QStringList) -> QString {
         return QString::number(settings.f_stop - settings.f_start, 'f', 0);
@@ -848,10 +848,10 @@ void SpectrumAnalyzer::SetupSCPI()
     scpi_freq->add(new SCPICommand("START", [=](QStringList params) -> QString {
         unsigned long long newval;
         if(!SCPI::paramToULongLong(params, 0, newval)) {
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         } else {
             SetStartFreq(newval);
-            return "";
+            return SCPI::getResultName(SCPI::Result::Empty);
         }
     }, [=](QStringList) -> QString {
         return QString::number(settings.f_start, 'f', 0);
@@ -859,10 +859,10 @@ void SpectrumAnalyzer::SetupSCPI()
     scpi_freq->add(new SCPICommand("CENTer", [=](QStringList params) -> QString {
         unsigned long long newval;
         if(!SCPI::paramToULongLong(params, 0, newval)) {
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         } else {
             SetCenterFreq(newval);
-            return "";
+            return SCPI::getResultName(SCPI::Result::Empty);
         }
     }, [=](QStringList) -> QString {
         return QString::number((settings.f_start + settings.f_stop)/2, 'f', 0);
@@ -870,10 +870,10 @@ void SpectrumAnalyzer::SetupSCPI()
     scpi_freq->add(new SCPICommand("STOP", [=](QStringList params) -> QString {
         unsigned long long newval;
         if(!SCPI::paramToULongLong(params, 0, newval)) {
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         } else {
             SetStopFreq(newval);
-            return "";
+            return SCPI::getResultName(SCPI::Result::Empty);
         }
     }, [=](QStringList) -> QString {
         return QString::number(settings.f_stop, 'f', 0);
@@ -881,29 +881,29 @@ void SpectrumAnalyzer::SetupSCPI()
     scpi_freq->add(new SCPICommand("FULL", [=](QStringList params) -> QString {
         Q_UNUSED(params)
         SetFullSpan();
-        return "";
+        return SCPI::getResultName(SCPI::Result::Empty);
     }, nullptr));
     scpi_freq->add(new SCPICommand("ZERO", [=](QStringList params) -> QString {
         Q_UNUSED(params)
         SetZeroSpan();
-        return "";
+        return SCPI::getResultName(SCPI::Result::Empty);
     }, nullptr));
     auto scpi_acq = new SCPINode("ACQuisition");
     SCPINode::add(scpi_acq);
     scpi_acq->add(new SCPICommand("RBW", [=](QStringList params) -> QString {
         unsigned long long newval;
         if(!SCPI::paramToULongLong(params, 0, newval)) {
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         } else {
             SetRBW(newval);
-            return "";
+            return SCPI::getResultName(SCPI::Result::Empty);
         }
     }, [=](QStringList) -> QString {
         return QString::number(settings.RBW);
     }));
     scpi_acq->add(new SCPICommand("WINDow", [=](QStringList params) -> QString {
         if (params.size() != 1) {
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         }
         if (params[0] == "NONE") {
             SetWindow(Window::None);
@@ -916,19 +916,19 @@ void SpectrumAnalyzer::SetupSCPI()
         } else {
             return "INVALID WINDOW";
         }
-        return "";
+        return SCPI::getResultName(SCPI::Result::Empty);
     }, [=](QStringList) -> QString {
         switch((Window) settings.WindowType) {
         case Window::None: return "NONE";
         case Window::Kaiser: return "KAISER";
         case Window::Hann: return "HANN";
         case Window::FlatTop: return "FLATTOP";
-        default: return "ERROR";
+        default: return SCPI::getResultName(SCPI::Result::Error);
         }
     }));
     scpi_acq->add(new SCPICommand("DETector", [=](QStringList params) -> QString {
         if (params.size() != 1) {
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         }
         if (params[0] == "+PEAK") {
             SetDetector(Detector::PPeak);
@@ -943,7 +943,7 @@ void SpectrumAnalyzer::SetupSCPI()
         } else {
             return "INVALID MDOE";
         }
-        return "";
+        return SCPI::getResultName(SCPI::Result::Empty);
     }, [=](QStringList) -> QString {
         switch((Detector) settings.Detector) {
         case Detector::PPeak: return "+PEAK";
@@ -951,16 +951,16 @@ void SpectrumAnalyzer::SetupSCPI()
         case Detector::Normal: return "NORMAL";
         case Detector::Sample: return "SAMPLE";
         case Detector::Average: return "AVERAGE";
-        default: return "ERROR";
+        default: return SCPI::getResultName(SCPI::Result::Error);
         }
     }));
     scpi_acq->add(new SCPICommand("AVG", [=](QStringList params) -> QString {
         unsigned long long newval;
         if(!SCPI::paramToULongLong(params, 0, newval)) {
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         } else {
             SetAveraging(newval);
-            return "";
+            return SCPI::getResultName(SCPI::Result::Empty);
         }
     }, [=](QStringList) -> QString {
         return QString::number(averages);
@@ -976,59 +976,59 @@ void SpectrumAnalyzer::SetupSCPI()
     }));
     scpi_acq->add(new SCPICommand("SIGid", [=](QStringList params) -> QString {
         if (params.size() != 1) {
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         }
         if(params[0] == "1" || params[0] == "TRUE") {
             SetSignalID(true);
         } else if(params[0] == "0" || params[0] == "FALSE") {
             SetSignalID(false);
         } else {
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         }
-        return "";
+        return SCPI::getResultName(SCPI::Result::Empty);
     }, [=](QStringList) -> QString {
-        return settings.SignalID ? "TRUE" : "FALSE";
+        return settings.SignalID ? SCPI::getResultName(SCPI::Result::True) : SCPI::getResultName(SCPI::Result::False);
     }));
     scpi_acq->add(new SCPICommand("SINGLE", [=](QStringList params) -> QString {
         bool single;
         if(!SCPI::paramToBool(params, 0, single)) {
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         } else {
             SetSingleSweep(single);
-            return "";
+            return SCPI::getResultName(SCPI::Result::Empty);
         }
     }, [=](QStringList) -> QString {
-        return singleSweep ? "TRUE" : "FALSE";
+        return singleSweep ? SCPI::getResultName(SCPI::Result::True): SCPI::getResultName(SCPI::Result::False);
     }));
     auto scpi_tg = new SCPINode("TRACKing");
     SCPINode::add(scpi_tg);
     scpi_tg->add(new SCPICommand("ENable", [=](QStringList params) -> QString {
         if (params.size() != 1) {
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         }
         if(params[0] == "1" || params[0] == "TRUE") {
             SetTGEnabled(true);
         } else if(params[0] == "0" || params[0] == "FALSE") {
             SetTGEnabled(false);
         } else {
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         }
-        return "";
+        return SCPI::getResultName(SCPI::Result::Empty);
     }, [=](QStringList) -> QString {
-        return settings.trackingGenerator ? "TRUE" : "FALSE";
+        return settings.trackingGenerator ? SCPI::getResultName(SCPI::Result::True) : SCPI::getResultName(SCPI::Result::False);
     }));
     scpi_tg->add(new SCPICommand("Port", [=](QStringList params) -> QString {
         if (params.size() != 1) {
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         }
         if(params[0] == "1") {
             SetTGPort(0);
         } else if(params[0] == "2") {
             SetTGPort(1);
         } else {
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         }
-        return "";
+        return SCPI::getResultName(SCPI::Result::Empty);
     }, [=](QStringList) -> QString {
         return settings.trackingGeneratorPort ? "2" : "1";
     }));
@@ -1036,10 +1036,10 @@ void SpectrumAnalyzer::SetupSCPI()
         double newval;
         if(!SCPI::paramToDouble(params, 0, newval)) {
 
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         } else {
             SetTGLevel(newval);
-            return "";
+            return SCPI::getResultName(SCPI::Result::Empty);
         }
     }, [=](QStringList) -> QString {
         return QString::number(settings.trackingPower / 100.0);
@@ -1047,10 +1047,10 @@ void SpectrumAnalyzer::SetupSCPI()
     scpi_tg->add(new SCPICommand("OFFset", [=](QStringList params) -> QString {
         long newval;
         if(!SCPI::paramToLong(params, 0, newval)) {
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         } else {
             SetTGOffset(newval);
-            return "";
+            return SCPI::getResultName(SCPI::Result::Empty);
         }
     }, [=](QStringList) -> QString {
         return QString::number(settings.trackingGeneratorOffset);
@@ -1059,18 +1059,18 @@ void SpectrumAnalyzer::SetupSCPI()
     scpi_tg->add(scpi_norm);
     scpi_norm->add(new SCPICommand("ENable", [=](QStringList params) -> QString {
         if (params.size() != 1) {
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         }
         if(params[0] == "1" || params[0] == "TRUE") {
             EnableNormalization(true);
         } else if(params[0] == "0" || params[0] == "FALSE") {
             EnableNormalization(false);
         } else {
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         }
-        return "";
+        return SCPI::getResultName(SCPI::Result::Empty);
     }, [=](QStringList) -> QString {
-        return normalize.active ? "TRUE" : "FALSE";
+        return normalize.active ? SCPI::getResultName(SCPI::Result::True) : SCPI::getResultName(SCPI::Result::False);
     }));
     scpi_norm->add(new SCPICommand("MEASure", [=](QStringList params) -> QString {
         Q_UNUSED(params)
@@ -1080,10 +1080,10 @@ void SpectrumAnalyzer::SetupSCPI()
     scpi_norm->add(new SCPICommand("LVL", [=](QStringList params) -> QString {
         double newval;
         if(!SCPI::paramToDouble(params, 0, newval)) {
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         } else {
             SetNormalizationLevel(newval);
-            return "";
+            return SCPI::getResultName(SCPI::Result::Empty);
         }
     }, [=](QStringList) -> QString {
         return QString::number(normalize.Level->value());

--- a/Software/PC_Application/VNA/vna.cpp
+++ b/Software/PC_Application/VNA/vna.cpp
@@ -1290,11 +1290,11 @@ void VNA::SetupSCPI()
                 return "";
             } else if(params[0] == "POWER") {
                 SetSweepType(SweepType::Power);
-                return "";
+                return SCPI::getResultName(SCPI::Result::Empty);
             }
         }
         // either no parameter or invalid
-        return "ERROR";
+        return SCPI::getResultName(SCPI::Result::Error);
     }, [=](QStringList) -> QString {
         return settings.sweepType == SweepType::Frequency ? "FREQUENCY" : "POWER";
     }));
@@ -1303,10 +1303,10 @@ void VNA::SetupSCPI()
     scpi_freq->add(new SCPICommand("SPAN", [=](QStringList params) -> QString {
         unsigned long long newval;
         if(!SCPI::paramToULongLong(params, 0, newval)) {
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         } else {
             SetSpan(newval);
-            return "";
+            return SCPI::getResultName(SCPI::Result::Empty);
         }
     }, [=](QStringList) -> QString {
         return QString::number(settings.Freq.stop - settings.Freq.start, 'f', 0);
@@ -1314,10 +1314,10 @@ void VNA::SetupSCPI()
     scpi_freq->add(new SCPICommand("START", [=](QStringList params) -> QString {
         unsigned long long newval;
         if(!SCPI::paramToULongLong(params, 0, newval)) {
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         } else {
             SetStartFreq(newval);
-            return "";
+            return SCPI::getResultName(SCPI::Result::Empty);
         }
     }, [=](QStringList) -> QString {
         return QString::number(settings.Freq.start, 'f', 0);
@@ -1325,10 +1325,10 @@ void VNA::SetupSCPI()
     scpi_freq->add(new SCPICommand("CENTer", [=](QStringList params) -> QString {
         unsigned long long newval;
         if(!SCPI::paramToULongLong(params, 0, newval)) {
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         } else {
             SetCenterFreq(newval);
-            return "";
+            return SCPI::getResultName(SCPI::Result::Empty);
         }
     }, [=](QStringList) -> QString {
         return QString::number((settings.Freq.start + settings.Freq.stop)/2, 'f', 0);
@@ -1336,10 +1336,10 @@ void VNA::SetupSCPI()
     scpi_freq->add(new SCPICommand("STOP", [=](QStringList params) -> QString {
         unsigned long long newval;
         if(!SCPI::paramToULongLong(params, 0, newval)) {
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         } else {
             SetStopFreq(newval);
-            return "";
+            return SCPI::getResultName(SCPI::Result::Empty);
         }
     }, [=](QStringList) -> QString {
         return QString::number(settings.Freq.stop, 'f', 0);
@@ -1347,22 +1347,22 @@ void VNA::SetupSCPI()
     scpi_freq->add(new SCPICommand("FULL", [=](QStringList params) -> QString {
         Q_UNUSED(params)
         SetFullSpan();
-        return "";
+        return SCPI::getResultName(SCPI::Result::Empty);
     }, nullptr));
     scpi_freq->add(new SCPICommand("ZERO", [=](QStringList params) -> QString {
         Q_UNUSED(params)
         SetZeroSpan();
-        return "";
+        return SCPI::getResultName(SCPI::Result::Empty);
     }, nullptr));
     auto scpi_power = new SCPINode("POWer");
     SCPINode::add(scpi_power);
     scpi_power->add(new SCPICommand("START", [=](QStringList params) -> QString {
         double newval;
         if(!SCPI::paramToDouble(params, 0, newval)) {
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         } else {
             SetStartPower(newval);
-            return "";
+            return SCPI::getResultName(SCPI::Result::Empty);
         }
     }, [=](QStringList) -> QString {
         return QString::number(settings.Power.start);
@@ -1370,10 +1370,10 @@ void VNA::SetupSCPI()
     scpi_power->add(new SCPICommand("STOP", [=](QStringList params) -> QString {
         double newval;
         if(!SCPI::paramToDouble(params, 0, newval)) {
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         } else {
             SetStopPower(newval);
-            return "";
+            return SCPI::getResultName(SCPI::Result::Empty);
         }
     }, [=](QStringList) -> QString {
         return QString::number(settings.Power.stop);
@@ -1383,10 +1383,10 @@ void VNA::SetupSCPI()
     scpi_acq->add(new SCPICommand("IFBW", [=](QStringList params) -> QString {
         unsigned long long newval;
         if(!SCPI::paramToULongLong(params, 0, newval)) {
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         } else {
             SetIFBandwidth(newval);
-            return "";
+            return SCPI::getResultName(SCPI::Result::Empty);
         }
     }, [=](QStringList) -> QString {
         return QString::number(settings.bandwidth);
@@ -1394,10 +1394,10 @@ void VNA::SetupSCPI()
     scpi_acq->add(new SCPICommand("POINTS", [=](QStringList params) -> QString {
         unsigned long long newval;
         if(!SCPI::paramToULongLong(params, 0, newval)) {
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         } else {
             SetPoints(newval);
-            return "";
+            return SCPI::getResultName(SCPI::Result::Empty);
         }
     }, [=](QStringList) -> QString {
         return QString::number(settings.npoints);
@@ -1405,10 +1405,10 @@ void VNA::SetupSCPI()
     scpi_acq->add(new SCPICommand("AVG", [=](QStringList params) -> QString {
         unsigned long long newval;
         if(!SCPI::paramToULongLong(params, 0, newval)) {
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         } else {
             SetAveraging(newval);
-            return "";
+            return SCPI::getResultName(SCPI::Result::Empty);
         }
     }, [=](QStringList) -> QString {
         return QString::number(averages);
@@ -1417,7 +1417,7 @@ void VNA::SetupSCPI()
         return QString::number(average.getLevel());
     }));
     scpi_acq->add(new SCPICommand("FINished", nullptr, [=](QStringList) -> QString {
-        return average.getLevel() == averages ? "TRUE" : "FALSE";
+        return average.getLevel() == averages ? SCPI::getResultName(SCPI::Result::True) : SCPI::getResultName(SCPI::Result::False);
     }));
     scpi_acq->add(new SCPICommand("LIMit", nullptr, [=](QStringList) -> QString {
         return central->allLimitsPassing() ? "PASS" : "FAIL";
@@ -1425,23 +1425,23 @@ void VNA::SetupSCPI()
     scpi_acq->add(new SCPICommand("SINGLE", [=](QStringList params) -> QString {
         bool single;
         if(!SCPI::paramToBool(params, 0, single)) {
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         } else {
             SetSingleSweep(single);
-            return "";
+            return SCPI::getResultName(SCPI::Result::Empty);
         }
     }, [=](QStringList) -> QString {
-        return singleSweep ? "TRUE" : "FALSE";
+        return singleSweep ? SCPI::getResultName(SCPI::Result::True) : SCPI::getResultName(SCPI::Result::False);
     }));
     auto scpi_stim = new SCPINode("STIMulus");
     SCPINode::add(scpi_stim);
     scpi_stim->add(new SCPICommand("LVL", [=](QStringList params) -> QString {
         double newval;
         if(!SCPI::paramToDouble(params, 0, newval)) {
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         } else {
             SetSourceLevel(newval);
-            return "";
+            return SCPI::getResultName(SCPI::Result::Empty);
         }
     }, [=](QStringList) -> QString {
         return QString::number(settings.Freq.excitation_power);
@@ -1449,10 +1449,10 @@ void VNA::SetupSCPI()
     scpi_stim->add(new SCPICommand("FREQuency", [=](QStringList params) -> QString {
         unsigned long long newval;
         if(!SCPI::paramToULongLong(params, 0, newval)) {
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         } else {
             SetPowerSweepFrequency(newval);
-            return "";
+            return SCPI::getResultName(SCPI::Result::Empty);
         }
     }, [=](QStringList) -> QString {
         return QString::number(settings.Power.frequency, 'f', 0);
@@ -1462,12 +1462,12 @@ void VNA::SetupSCPI()
     SCPINode::add(scpi_cal);
     scpi_cal->add(new SCPICommand("TYPE", [=](QStringList params) -> QString {
         if(params.size() != 1) {
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         } else {
             auto type = Calibration::TypeFromString(params[0].replace('_', ' '));
             if(type == Calibration::Type::Last) {
                 // failed to parse string
-                return "ERROR";
+                return SCPI::getResultName(SCPI::Result::Error);
             } else if(type == Calibration::Type::None) {
                 DisableCalibration();
             } else {
@@ -1475,11 +1475,11 @@ void VNA::SetupSCPI()
                 if(cal.calculationPossible(type)) {
                     ApplyCalibration(type);
                 } else {
-                    return "ERROR";
+                    return SCPI::getResultName(SCPI::Result::Error);
                 }
             }
         }
-        return "";
+        return SCPI::getResultName(SCPI::Result::Empty);
     }, [=](QStringList) -> QString {
         auto ret = Calibration::TypeToString(cal.getType());
         ret.replace(' ', '_');
@@ -1488,43 +1488,43 @@ void VNA::SetupSCPI()
     scpi_cal->add(new SCPICommand("MEASure", [=](QStringList params) -> QString {
         if(params.size() != 1 || CalibrationMeasurementActive() || !window->getDevice() || Mode::getActiveMode() != this) {
             // no measurement specified, still busy or invalid mode
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         } else {
             auto meas = Calibration::MeasurementFromString(params[0].replace('_', ' '));
             if(meas == Calibration::Measurement::Last) {
                 // failed to parse string
-                return "ERROR";
+                return SCPI::getResultName(SCPI::Result::Error);
             } else {
                 std::set<Calibration::Measurement> m;
                 m.insert(meas);
                 StartCalibrationMeasurements(m);
             }
         }
-        return "";
+        return SCPI::getResultName(SCPI::Result::Empty);
     }, nullptr));
     scpi_cal->add(new SCPICommand("BUSy", nullptr, [=](QStringList) -> QString {
-        return CalibrationMeasurementActive() ? "TRUE" : "FALSE";
+        return CalibrationMeasurementActive() ? SCPI::getResultName(SCPI::Result::True) : SCPI::getResultName(SCPI::Result::False);
     }));
     scpi_cal->add(new SCPICommand("SAVE", [=](QStringList params) -> QString {
         if(params.size() != 1 || !calValid) {
             // no filename given or no calibration active
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         }
         if(!cal.saveToFile(params[0])) {
             // some error when writing the calibration file
-            return "ERROR";
+            return SCPI::getResultName(SCPI::Result::Error);
         }
         calEdited = false;
-        return "";
+        return SCPI::getResultName(SCPI::Result::Empty);
     }, nullptr));
     scpi_cal->add(new SCPICommand("LOAD", nullptr, [=](QStringList params) -> QString {
         if(params.size() != 1) {
             // no filename given or no calibration active
-            return "FALSE";
+            return SCPI::getResultName(SCPI::Result::False);
         }
         if(!cal.openFromFile(params[0])) {
             // some error when loading the calibration file
-            return "FALSE";
+            return SCPI::getResultName(SCPI::Result::False);
         }
         if(cal.getType() == Calibration::Type::None) {
             DisableCalibration();
@@ -1532,7 +1532,7 @@ void VNA::SetupSCPI()
             ApplyCalibration(cal.getType());
         }
         calEdited = false;
-        return "TRUE";
+        return SCPI::getResultName(SCPI::Result::True);
     }));
 }
 

--- a/Software/PC_Application/scpi.cpp
+++ b/Software/PC_Application/scpi.cpp
@@ -79,6 +79,20 @@ bool SCPI::paramToBool(QStringList params, int index, bool &dest)
     return okay;
 }
 
+QString SCPI::getResultName(SCPI::Result r)
+{
+    switch (r) {
+    case Result::Empty:
+        return "";
+    case Result::Error:
+        return "ERROR";
+    case Result::False:
+        return "FALSE";
+    case Result::True:
+        return "TRUE";
+    }
+}
+
 void SCPI::input(QString line)
 {
     auto cmds = line.split(";");
@@ -191,7 +205,7 @@ QString SCPINode::parse(QString cmd, SCPINode* &lastNode)
             }
         }
         // unable to find subnode
-        return "ERROR";
+        return SCPI::getResultName(SCPI::Result::Error);
     } else {
         // no more levels, search for command
         auto params = cmd.split(" ");
@@ -214,14 +228,14 @@ QString SCPINode::parse(QString cmd, SCPINode* &lastNode)
             }
         }
         // couldn't find command
-        return "ERROR";
+        return SCPI::getResultName(SCPI::Result::Error);
     }
 }
 
 QString SCPICommand::execute(QStringList params)
 {
     if(fn_cmd == nullptr) {
-        return "ERROR";
+        return SCPI::getResultName(SCPI::Result::Error);
     } else {
         return fn_cmd(params);
     }
@@ -230,7 +244,7 @@ QString SCPICommand::execute(QStringList params)
 QString SCPICommand::query(QStringList params)
 {
     if(fn_query == nullptr) {
-        return "ERROR";
+        return SCPI::getResultName(SCPI::Result::Error);
     } else {
         return fn_query(params);
     }

--- a/Software/PC_Application/scpi.h
+++ b/Software/PC_Application/scpi.h
@@ -59,6 +59,15 @@ public:
     static bool paramToLong(QStringList params, int index, long &dest);
     static bool paramToBool(QStringList params, int index, bool &dest);
 
+    enum class Result {
+        Empty,
+        Error,
+        False,
+        True
+    };
+
+    static QString getResultName(SCPI::Result r);
+
 public slots:
     void input(QString line);
 signals:


### PR DESCRIPTION
When returning scpi values, there are common options
that are shared between different commands. This
change introduce a way to define those values in a
single place.

Signed-off-by: Kiara Navarro <sophiekovalevsky@fedoraproject.org>