### PR TITLE
Import/export limit lines for reuse

### DIFF
--- a/Software/PC_Application/Traces/XYPlotConstantLineEditDialog.ui
+++ b/Software/PC_Application/Traces/XYPlotConstantLineEditDialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>Edit line</string>
   </property>
   <property name="modal">
    <bool>true</bool>

--- a/Software/PC_Application/Traces/xyplotaxisdialog.h
+++ b/Software/PC_Application/Traces/xyplotaxisdialog.h
@@ -26,6 +26,7 @@ private:
     bool isSupported(XAxis::Type type);
     Ui::XYplotAxisDialog *ui;
     TraceXYPlot *plot;
+    void removeLine(int index);
 };
 
 #endif // XYPLOTAXISDIALOG_H

--- a/Software/PC_Application/Traces/xyplotaxisdialog.ui
+++ b/Software/PC_Application/Traces/xyplotaxisdialog.ui
@@ -490,6 +490,34 @@
          </widget>
         </item>
         <item>
+         <widget class="QPushButton" name="exportLines">
+          <property name="toolTip">
+           <string>Export</string>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+          <property name="icon">
+           <iconset resource="../icons.qrc">
+            <normaloff>:/icons/export.png</normaloff>:/icons/export.png</iconset>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="importLines">
+          <property name="toolTip">
+           <string>Import</string>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+          <property name="icon">
+           <iconset resource="../icons.qrc">
+            <normaloff>:/icons/import.png</normaloff>:/icons/import.png</iconset>
+          </property>
+         </widget>
+        </item>
+        <item>
          <spacer name="verticalSpacer">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
@@ -564,8 +592,8 @@
   </connection>
  </connections>
  <buttongroups>
-  <buttongroup name="Y2group"/>
   <buttongroup name="Y1group"/>
   <buttongroup name="Xgroup"/>
+  <buttongroup name="Y2group"/>
  </buttongroups>
 </ui>


### PR DESCRIPTION
Implement import and export of limit lines via Axis setup dialog.

Used existing toJSON / fromJSON methods for limit lines, so keeping the same format as in the overall .setup file. This way, the "limitLines" section could be extracted manually from the .setup file to a separate one and should be imported successfully. I didn't test it, though...

I copied Jan's code for file save and open dialogs and for json parsing. It would be better to refactor those to a separate place but I am leaving it for a better moment.