### PR TITLE
fix duplicate condition in match() string comparisons

### DIFF
--- a/Software/PC_Application/LibreVNA-GUI/scpi.cpp
+++ b/Software/PC_Application/LibreVNA-GUI/scpi.cpp
@@ -17,7 +17,7 @@ bool SCPI::match(QString s1, QString s2)
 {
     if (s1.compare(s2, Qt::CaseInsensitive) == 0
      || s1.compare(alternateName(s2), Qt::CaseInsensitive) == 0
-     || alternateName(s1).compare(alternateName(s2), Qt::CaseInsensitive) == 0
+     || alternateName(s1).compare(s2, Qt::CaseInsensitive) == 0
      || alternateName(s1).compare(alternateName(s2), Qt::CaseInsensitive) == 0) {
         return true;
     } else {


### PR DESCRIPTION
Minor correction to SCPI::match() method, where one compare condition is repeated and another omitted. This can result in a false mismatch for a valid command string.

Change should now cover matching of each expected combination of standard and alternate command strings.