### PR TITLE
replace USB protocol literals with named constants

### DIFF
--- a/Software/PC_Application/LibreVNA-GUI/Device/firmwareupdatedialog.cpp
+++ b/Software/PC_Application/LibreVNA-GUI/Device/firmwareupdatedialog.cpp
@@ -1,6 +1,7 @@
 #include "firmwareupdatedialog.h"
 
 #include "ui_firmwareupdatedialog.h"
+#include "../../VNA_embedded/Application/Communication/PacketConstants.h"
 
 #include <QFileDialog>
 #include <QStyle>
@@ -49,7 +50,7 @@ void FirmwareUpdateDialog::on_bStart_clicked()
     }
     file->seek(0);
     addStatus("Evaluating file...");
-    if(file->size() % Protocol::FirmwareChunkSize != 0) {
+    if(file->size() % PacketConstants::FW_CHUNK_SIZE != 0) {
         abortWithError("Invalid file size");
         return;
     }
@@ -132,7 +133,7 @@ void FirmwareUpdateDialog::receivedAck()
         timer.start(1000);
         break;
     case State::TransferringData:
-        transferredBytes += Protocol::FirmwareChunkSize;
+        transferredBytes += PacketConstants::FW_CHUNK_SIZE;
         ui->progress->setValue(100 * transferredBytes / file->size());
         if(transferredBytes >= file->size()) {
             // complete file transferred
@@ -175,6 +176,6 @@ void FirmwareUpdateDialog::sendNextFirmwareChunk()
 {
     Protocol::FirmwarePacket fw;
     fw.address = transferredBytes;
-    file->read((char*) &fw.data, Protocol::FirmwareChunkSize);
+    file->read((char*) &fw.data, PacketConstants::FW_CHUNK_SIZE);
     dev->SendFirmwareChunk(fw);
 }

--- a/Software/PC_Application/LibreVNA-GUI/LibreVNA-GUI.pro
+++ b/Software/PC_Application/LibreVNA-GUI/LibreVNA-GUI.pro
@@ -1,5 +1,6 @@
 HEADERS += \
     ../../VNA_embedded/Application/Communication/Protocol.hpp \
+    ../../VNA_embedded/Application/Communication/PacketConstants.h \
     Calibration/LibreCAL/caldevice.h \
     Calibration/LibreCAL/librecaldialog.h \
     Calibration/LibreCAL/usbdevice.h \

--- a/Software/VNA_embedded/Application/Communication/PacketConstants.h
+++ b/Software/VNA_embedded/Application/Communication/PacketConstants.h
@@ -1,0 +1,49 @@
+#pragma once
+
+
+#include <cstdint>
+
+
+namespace PacketConstants {
+	//  USB protocol packet field constants
+
+	static constexpr uint8_t PCKT_HEADER_DATA = 0x5A;
+
+
+	/////////////////////////////////////////////////////////////
+	//  General packet structure field sizes and offsets in bytes
+	static constexpr uint8_t PCKT_HEADER_OFFSET = 0;
+	static constexpr uint8_t PCKT_HEADER_LEN = 1;
+	static constexpr uint8_t PCKT_LENGTH_OFFSET = PCKT_HEADER_OFFSET + PCKT_HEADER_LEN;  // offset one byte
+	static constexpr uint8_t PCKT_LENGTH_LEN = 2;
+	static constexpr uint8_t PCKT_TYPE_OFFSET = PCKT_LENGTH_OFFSET + PCKT_LENGTH_LEN;  // offset three bytes
+	static constexpr uint8_t PCKT_TYPE_LEN = 1;
+	static constexpr uint8_t PCKT_PAYLOAD_OFFSET = PCKT_TYPE_OFFSET + PCKT_TYPE_LEN;  // offset four bytes
+	static constexpr uint8_t PCKT_CRC_LEN = 4;
+
+	static constexpr uint8_t PCKT_COMBINED_HEADER_LEN = PCKT_HEADER_LEN + PCKT_LENGTH_LEN + PCKT_TYPE_LEN;  //  combined length of fields preceding payload
+	static constexpr uint8_t PCKT_EXCL_PAYLOAD_LEN = PCKT_COMBINED_HEADER_LEN + PCKT_CRC_LEN;  // combined length of all packet fields, excluding payload
+
+	/////////////////////////////////////////////////////////////
+	//  Payload content
+
+	//  Firmware packets
+	static constexpr uint16_t FW_CHUNK_SIZE = 256;
+
+	//  VNADataPoint payload fields in bytes
+	static constexpr uint8_t DPNT_FREQ_LEN = 8;
+	static constexpr uint8_t DPNT_POW_LVL_LEN = 2;
+	static constexpr uint8_t DPNT_PNT_NUM_LEN = 2;
+	static constexpr uint8_t DPNT_REAL_PART_LEN = 4;
+	static constexpr uint8_t DPNT_IMAG_PART_LEN = 4;
+	static constexpr uint8_t DPNT_DESC_LEN = 1;
+
+	// VNADataPoint configuration bitmask offsets in bits
+	static constexpr uint8_t DPNT_CONF_P1_OFFSET = 0;
+	static constexpr uint8_t DPNT_CONF_P2_OFFSET = 1;
+	static constexpr uint8_t DPNT_CONF_P3_OFFSET = 2;
+	static constexpr uint8_t DPNT_CONF_P4_OFFSET = 3;
+	static constexpr uint8_t DPNT_CONF_REF_OFFSET = 4;
+	static constexpr uint8_t DPNT_CONF_STAGE_OFFSET = 5;
+
+}


### PR DESCRIPTION
Issue:
The USB communication protocol uses literals for data structuring and indexing, making the code challenging to understand and maintain. An update to packet structure would require manually locating and interpreting individual literal values with prior knowledge of their significance.

Fix:
This commit introduces a separate header file and namespace, `PacketConstants`, containing named constants to replace field-specific literals. It also standardizes buffer incrementation in `encode()`/`decode()` methods, and reduces some ambiguity with combined packet header length vs distinct header field length.

Constants were created in a separate header file so that they might easily be included in host projects which require the packet structure, without the device protocol declarations/implementations. 

Firmware has been built with CubeMX 1.8.0 and tested on device.