### PR TITLE
validate math formula on text change

### DIFF
--- a/Software/PC_Application/LibreVNA-GUI/Traces/traceeditdialog.cpp
+++ b/Software/PC_Application/LibreVNA-GUI/Traces/traceeditdialog.cpp
@@ -147,6 +147,7 @@ TraceEditDialog::TraceEditDialog(Trace &t, QWidget *parent) :
 
     // Math source configuration
     if(t.getModel()) {
+        ui->lMathFormula->setText(t.getMathFormula());
         connect(ui->lMathFormula, &QLineEdit::textChanged, [&](){
             t.setMathFormula(ui->lMathFormula->text());
             ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(TraceEditDialog::validate());

--- a/Software/PC_Application/LibreVNA-GUI/Traces/traceeditdialog.cpp
+++ b/Software/PC_Application/LibreVNA-GUI/Traces/traceeditdialog.cpp
@@ -149,7 +149,7 @@ TraceEditDialog::TraceEditDialog(Trace &t, QWidget *parent) :
     if(t.getModel()) {
         connect(ui->lMathFormula, &QLineEdit::textChanged, [&](){
             t.setMathFormula(ui->lMathFormula->text());
-            ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(t.mathFormularValid());
+            ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(TraceEditDialog::validate());
         });
 
         ui->mathTraceTable->setColumnCount(2);
@@ -212,7 +212,7 @@ TraceEditDialog::TraceEditDialog(Trace &t, QWidget *parent) :
                 t.addMathSource(trace, item->text());
             }
             ui->mathTraceTable->blockSignals(false);
-            ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(t.mathFormularValid());
+            ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(TraceEditDialog::validate());
         });
     }
 
@@ -334,6 +334,14 @@ TraceEditDialog::TraceEditDialog(Trace &t, QWidget *parent) :
 TraceEditDialog::~TraceEditDialog()
 {
     delete ui;
+}
+
+bool TraceEditDialog::validate()
+{
+    auto valid = trace.mathFormularValid();
+    auto color = valid ? "background-color:lightgreen" : "background-color:lightcoral";
+    ui->lMathFormula->setStyleSheet(color);
+    return valid;
 }
 
 void TraceEditDialog::okClicked()

--- a/Software/PC_Application/LibreVNA-GUI/Traces/traceeditdialog.cpp
+++ b/Software/PC_Application/LibreVNA-GUI/Traces/traceeditdialog.cpp
@@ -147,8 +147,7 @@ TraceEditDialog::TraceEditDialog(Trace &t, QWidget *parent) :
 
     // Math source configuration
     if(t.getModel()) {
-        ui->lMathFormula->setText(t.getMathFormula());
-        connect(ui->lMathFormula, &QLineEdit::editingFinished, [&](){
+        connect(ui->lMathFormula, &QLineEdit::textChanged, [&](){
             t.setMathFormula(ui->lMathFormula->text());
             ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(t.mathFormularValid());
         });

--- a/Software/PC_Application/LibreVNA-GUI/Traces/traceeditdialog.h
+++ b/Software/PC_Application/LibreVNA-GUI/Traces/traceeditdialog.h
@@ -47,6 +47,7 @@ public:
 
 private slots:
     void okClicked();
+    bool validate();
 
 private:
     Ui::TraceEditDialog *ui;


### PR DESCRIPTION
I've been writing a lot of formulae and I am new to the software and not sure about syntax. I've been clicking out of the input box to validate. Looks like I could also be [pressing enter](https://doc.qt.io/qt-6.2/qlineedit.html#editingFinished). It would be nice if this field was validated as I typed instead and so I have opened this draft pull request.

Validation will run on each change with no delay/debounce. Fiddled around with it a bit and didn't seem super heavy. Don't think there are additional side effects but I am not familiar with the codebase.