### PR TITLE
add LibreVNA-GUI build folder to .git-ignore

### DIFF
--- a/Software/PC_Application/.gitignore
+++ b/Software/PC_Application/.gitignore
@@ -77,6 +77,7 @@ Application
 /LibreVNA-Test/LibreVNA-Test
 /LibreVNA-GUI/users*appdatalocaltemp*
 /LibreVNA/build
+LibreVNA-GUI/build
 
 # qmake.stash
 LibreVNA-GUI/.qmake.stash


### PR DESCRIPTION
When working on the LibreVNA-GUI project directly in QT-Creator on Windows the build folder ends up in git changes.