### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/Software/VNA_embedded/Middlewares/Third_Party/FreeRTOS/Source/stream_buffer.c
+++ b/Software/VNA_embedded/Middlewares/Third_Party/FreeRTOS/Source/stream_buffer.c
@@ -254,8 +254,15 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
 		this is a quirk of the implementation that means otherwise the free
 		space would be reported as one byte smaller than would be logically
 		expected. */
-		xBufferSizeBytes++;
-		pucAllocatedMemory = ( uint8_t * ) pvPortMalloc( xBufferSizeBytes + sizeof( StreamBuffer_t ) ); /*lint !e9079 malloc() only returns void*. */
+		if( xBufferSizeBytes < ( xBufferSizeBytes + 1 + sizeof( StreamBuffer_t ) ) )
+        {
+            xBufferSizeBytes++;
+            pucAllocatedMemory = ( uint8_t * ) pvPortMalloc( xBufferSizeBytes + sizeof( StreamBuffer_t ) ); /*lint !e9079 malloc() only returns void*. */
+        }
+        else
+        {
+            pucAllocatedMemory = NULL;
+        }
 
 		if( pucAllocatedMemory != NULL )
 		{


### PR DESCRIPTION
Hi Development Team,

I identified a potential integer overflow in a clone function prvInitialiseNewStreamBuffer() in `Software/VNA_embedded/Middlewares/Third_Party/FreeRTOS/Source/stream_buffer.c` sourced from [FreeRTOS/FreeRTOS-Kernel](https://github.com/FreeRTOS/FreeRTOS-Kernel). This issue, originally reported in [CVE-2021-31572](https://nvd.nist.gov/vuln/detail/cve-2021-31572), was resolved in the repository via this commit https://github.com/FreeRTOS/FreeRTOS-Kernel/commit/d05b9c123f2bf9090bce386a244fc934ae44db5b.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience. Thank you!