### PR TITLE
change LM3370 MPN

### DIFF
--- a/Hardware/Kicad/PowerSupply.kicad_sch
+++ b/Hardware/Kicad/PowerSupply.kicad_sch
@@ -13075,7 +13075,7 @@
 				(hide yes)
 			)
 		)
-		(property "MPN" "LM3370SD-4221"
+		(property "MPN" "LM3370SD-3021"
 			(at 101.6 190.5 0)
 			(effects
 				(font
@@ -13970,7 +13970,7 @@
 				(hide yes)
 			)
 		)
-		(property "MPN" "LM3370SD-4221"
+		(property "MPN" "LM3370SD-3021"
 			(at 101.6 231.14 0)
 			(effects
 				(font
@@ -16667,7 +16667,7 @@
 				(hide yes)
 			)
 		)
-		(property "MPN" "LM3370SD-4221"
+		(property "MPN" "LM3370SD-3021"
 			(at 208.28 180.34 0)
 			(effects
 				(font


### PR DESCRIPTION
change LM 3370 MPN from LM3370SD-4221 to LM3370SD-3021;
The default output voltage of the LM3370SD-3021 BUCK 1 is 1.2V, which meets the VCCINT voltage requirements of the FPGA chip.
<img width="1064" height="568" alt="image" src="https://github.com/user-attachments/assets/62ddfe04-89f9-4c4a-b845-ff7e0b8a6e40" />
