### PR TITLE
Fix mode tab bar sizing on monitors with different DPI scale factors

### DIFF
--- a/Software/PC_Application/LibreVNA-GUI/modewindow.cpp
+++ b/Software/PC_Application/LibreVNA-GUI/modewindow.cpp
@@ -9,6 +9,7 @@
 #include <QMenuBar>
 #include <QActionGroup>
 #include <QEvent>
+#include <QStyle>
 
 ModeWindow::ModeWindow(ModeHandler* handler, AppWindow* aw):
     QWidget(nullptr),
@@ -16,6 +17,7 @@ ModeWindow::ModeWindow(ModeHandler* handler, AppWindow* aw):
     aw(aw)
 {
     SetupUi();
+    updateTabBarHeight();
 
     // Watch menu bar for resize events (triggered by DPI/screen changes)
     aw->menuBar()->installEventFilter(this);
@@ -47,7 +49,16 @@ bool ModeWindow::eventFilter(QObject *obj, QEvent *event)
 
 void ModeWindow::updateTabBarHeight()
 {
-    int h = aw->menuBar()->height();
+    // Compute height from font metrics instead of menuBar()->height()
+    // to avoid a feedback loop: the corner widget is embedded in the
+    // menu bar, so reading its height and writing it back causes growth.
+    auto fm = aw->menuBar()->fontMetrics();
+    int h = fm.height() + 2 * aw->style()->pixelMetric(QStyle::PM_MenuBarVMargin)
+                        + 2 * aw->style()->pixelMetric(QStyle::PM_MenuBarPanelWidth);
+    if (h == lastTabBarHeight) {
+        return;
+    }
+    lastTabBarHeight = h;
     cornerWidget->setMaximumHeight(h);
     tabBar->setStyleSheet("QTabBar::tab { height: " + QString::number(h) + "px;}");
     bAdd->setMaximumHeight(h);
@@ -59,10 +70,8 @@ void ModeWindow::SetupUi()
     cornerWidget->setLayout(new QHBoxLayout);
     cornerWidget->layout()->setSpacing(0);
     cornerWidget->layout()->setContentsMargins(0,0,0,0);
-    cornerWidget->setMaximumHeight(aw->menuBar()->height());
 
     tabBar = new QTabBar;
-    tabBar->setStyleSheet("QTabBar::tab { height: " + QString::number(aw->menuBar()->height()) + "px;}");
     tabBar->setTabsClosable(true);
     cornerWidget->layout()->addWidget(tabBar);
     connect(tabBar, &QTabBar::tabBarDoubleClicked, this, [=](int index) {
@@ -79,7 +88,6 @@ void ModeWindow::SetupUi()
         icon.addFile(QString::fromUtf8(":/icons/add.png"), QSize(), QIcon::Normal, QIcon::Off);
 
     bAdd->setIcon(icon);
-    bAdd->setMaximumHeight(aw->menuBar()->height());
     bAdd->setMaximumWidth(40);
 
     auto createNew = [=](Mode::Type type) {

--- a/Software/PC_Application/LibreVNA-GUI/modewindow.cpp
+++ b/Software/PC_Application/LibreVNA-GUI/modewindow.cpp
@@ -8,6 +8,7 @@
 #include <QPushButton>
 #include <QMenuBar>
 #include <QActionGroup>
+#include <QEvent>
 
 ModeWindow::ModeWindow(ModeHandler* handler, AppWindow* aw):
     QWidget(nullptr),
@@ -15,6 +16,9 @@ ModeWindow::ModeWindow(ModeHandler* handler, AppWindow* aw):
     aw(aw)
 {
     SetupUi();
+
+    // Watch menu bar for resize events (triggered by DPI/screen changes)
+    aw->menuBar()->installEventFilter(this);
 
     connect(handler, &ModeHandler::ModeCreated, this, &ModeWindow::ModeCreated);
     connect(handler, &ModeHandler::ModeClosed, this, &ModeWindow::ModeClosed);
@@ -33,9 +37,25 @@ ModeWindow::~ModeWindow()
 {
 }
 
+bool ModeWindow::eventFilter(QObject *obj, QEvent *event)
+{
+    if (obj == aw->menuBar() && event->type() == QEvent::Resize) {
+        updateTabBarHeight();
+    }
+    return QWidget::eventFilter(obj, event);
+}
+
+void ModeWindow::updateTabBarHeight()
+{
+    int h = aw->menuBar()->height();
+    cornerWidget->setMaximumHeight(h);
+    tabBar->setStyleSheet("QTabBar::tab { height: " + QString::number(h) + "px;}");
+    bAdd->setMaximumHeight(h);
+}
+
 void ModeWindow::SetupUi()
 {
-    auto cornerWidget = new QWidget();
+    cornerWidget = new QWidget();
     cornerWidget->setLayout(new QHBoxLayout);
     cornerWidget->layout()->setSpacing(0);
     cornerWidget->layout()->setContentsMargins(0,0,0,0);
@@ -49,7 +69,7 @@ void ModeWindow::SetupUi()
         renameMode(index);
     });
 
-    auto bAdd = new QPushButton();
+    bAdd = new QPushButton();
     QIcon icon;
     QString iconThemeName = QString::fromUtf8("list-add");
 

--- a/Software/PC_Application/LibreVNA-GUI/modewindow.h
+++ b/Software/PC_Application/LibreVNA-GUI/modewindow.h
@@ -5,6 +5,8 @@
 
 #include <QMenu>
 
+class QPushButton;
+
 class ModeWindow: public QWidget
 {
     Q_OBJECT
@@ -14,13 +16,19 @@ public:
 
     QMenu *getMenu() const;
 
+protected:
+    bool eventFilter(QObject *obj, QEvent *event) override;
+
 private:
     ModeHandler* handler;
     void SetupUi();
+    void updateTabBarHeight();
 
     void updateMenuActions();
     AppWindow* aw;
     QTabBar* tabBar;
+    QWidget* cornerWidget;
+    QPushButton* bAdd;
     QMenu *menu;
     QList<QAction*> menuActions;
     QActionGroup *modeMenuGroup;

--- a/Software/PC_Application/LibreVNA-GUI/modewindow.h
+++ b/Software/PC_Application/LibreVNA-GUI/modewindow.h
@@ -29,6 +29,7 @@ private:
     QTabBar* tabBar;
     QWidget* cornerWidget;
     QPushButton* bAdd;
+    int lastTabBarHeight = 0;
     QMenu *menu;
     QList<QAction*> menuActions;
     QActionGroup *modeMenuGroup;


### PR DESCRIPTION
## Problem

  The mode tab bar (embedded in the menu bar as a corner widget) gets its
  height from `menuBar()->height()` once at startup and bakes it into a
  stylesheet as a fixed pixel value. Two problems result:

  1. Moving the window to a monitor with a different DPI scale factor
     resizes the menu bar, but the tab bar keeps its startup height,
     breaking the menu bar layout.
  2. On fractional scale factors the captured height could feed back into
     the menu bar's own layout: the corner widget is inside the menu bar,
     so reading its height and writing it back caused unbounded growth of
     the menu/toolbar area.

  ## Fix

  - Watch the menu bar for resize events (triggered by screen/DPI changes)
    and update the tab bar height dynamically.
  - Compute the target height from font metrics and style margins, which
    are DPI-aware but independent of the menu bar's current layout, so no
    feedback loop is possible. Skip the update when the height is
    unchanged.

  Tested on Windows with a laptop display + two external monitors at
  different scale factors: tab bar now tracks the menu bar height
  correctly when dragging the window between monitors, with no growth
  loop on fractional scaling.