### PR TITLE
update Windows Qt to 6.8.3, fixes menus opening on the wrong screen

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
-          version: '6.2.4'
+          version: '6.8.3'
           arch: 'win64_mingw'
       
       - name: Download libusb

--- a/.github/workflows/Release_tag_stable.yml
+++ b/.github/workflows/Release_tag_stable.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
-          version: '6.2.4'
+          version: '6.8.3'
           arch: 'win64_mingw'
       
       - name: Download libusb


### PR DESCRIPTION
Qt 6.2.4 contains a screen-detection regression (QTBUG-101203, fixed in Qt 6.2.5): monitors reporting identical device names (two external monitors of the same model) are treated as a single physical screen. QMenu popups on the affected monitor then position against the wrong screen geometry, appearing detached from the menu bar or on another display entirely. The bug only reproduces with identical-model monitor pairs, which is why reports of it have been inconsistent.

Qt 6.8.3 (LTS) also includes later popup placement fixes (QTBUG-118695, QTBUG-120011) and reworked Windows DPI handling.