### PR TITLE
Update Windows builds to Qt 6.8.3 with matching MinGW toolchain

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -96,8 +96,9 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
-          version: '6.2.4'
+          version: '6.8.3'
           arch: 'win64_mingw'
+          tools: 'tools_mingw1310,qt.tools.win64_mingw1310'
       
       - name: Download libusb
         run: |
@@ -126,7 +127,7 @@ jobs:
         run: |
           cd Software/PC_Application/LibreVNA-GUI
           qmake LibreVNA-GUI.pro
-          make -j9
+          mingw32-make -j9
         shell: cmd
 
       - name: Deploy application

--- a/.github/workflows/Release_tag_stable.yml
+++ b/.github/workflows/Release_tag_stable.yml
@@ -112,8 +112,9 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
-          version: '6.2.4'
+          version: '6.8.3'
           arch: 'win64_mingw'
+          tools: 'tools_mingw1310,qt.tools.win64_mingw1310'
       
       - name: Download libusb
         run: |
@@ -137,7 +138,7 @@ jobs:
         run: |
           cd Software/PC_Application/LibreVNA-GUI
           qmake LibreVNA-GUI.pro
-          make -j9
+          mingw32-make -j9
         shell: cmd
 
       - name: Deploy application


### PR DESCRIPTION
## Summary

- update Windows builds from Qt 6.2.4 to Qt 6.8.3
- install Qt's matching MinGW 13.1 toolchain
- use `mingw32-make` explicitly in build and release workflows

## Motivation

Qt 6.2.4 contains a multi-monitor screen detection regression that can
cause menus to open on the wrong display when identical monitor models
are connected.

The initial Qt 6.8.3 update in #361 failed in GitHub Actions with:

    undefined reference to `__imp___argc`

The workflow installed Qt's MinGW binaries but compiled with the GitHub
runner's unrelated GCC 14.2 toolchain. This mixed incompatible MinGW
runtime and import libraries.

Installing the MinGW 13.1 toolchain supplied for Qt 6.8.3 and invoking
its `mingw32-make` keeps Qt, GCC, and the MinGW runtime ABI aligned.

## Validation

- parsed both modified workflow files as YAML
- verified both Windows jobs install `qt.tools.win64_mingw1310`
- verified both Windows jobs invoke `mingw32-make`
- ran `git diff --check`

Supersedes #361.

Credit to @hendorog for the original Qt 6.8.3 update in #361.